### PR TITLE
Improve bounding sphere radius computation

### DIFF
--- a/tests/Body.elm
+++ b/tests/Body.elm
@@ -1,0 +1,42 @@
+module Body exposing (..)
+
+import Physics.Body as Body exposing (Body)
+import Physics.Shape as Shape exposing (Shape)
+import Physics.Const as Const
+import Physics.ConvexPolyhedron as ConvexPolyhedron
+import Expect exposing (Expectation)
+import Math.Vector3 as Vec3 exposing (Vec3, vec3)
+import Test exposing (..)
+
+
+boundingSphereRadius : Test
+boundingSphereRadius =
+    describe "Body.boundingSphereRadius"
+        [ test "is set to zero by default" <|
+            \_ ->
+                Expect.equal 0 (Body.body |> .boundingSphereRadius)
+        , test "addShape computes the bounding sphere radius" <|
+            \_ ->
+                Body.body
+                    |> (Body.addShape (box (vec3 1 1 1)))
+                    |> .boundingSphereRadius
+                    |> Expect.within (Expect.Absolute 0.00001) (Vec3.length (vec3 1 1 1))
+        , test "addShape expands the bounding sphere radius" <|
+            \_ ->
+                Body.body
+                    |> (Body.addShape (box (vec3 1 1 1)))
+                    |> (Body.addShape (box (vec3 2 2 2)))
+                    |> .boundingSphereRadius
+                    |> Expect.within (Expect.Absolute 0.00001) (Vec3.length (vec3 2 2 2))
+        , test "addShape sets the bounding sphere radius to maxNumber for a plane shape" <|
+            \_ ->
+                Body.body
+                    |> (Body.addShape (Shape.Plane))
+                    |> .boundingSphereRadius
+                    |> Expect.equal Const.maxNumber
+        ]
+
+
+box : Vec3 -> Shape
+box halfExtends =
+    (Shape.Convex (ConvexPolyhedron.fromBox halfExtends))


### PR DESCRIPTION
1. Only expand the bounding sphere radius when shapes are added to a body
2. Apply shape transformation to each vertex of a convex shape