### PR TITLE
Groundwork for benchmarking

### DIFF
--- a/benchmarks/ConvexPolyhedron.elm
+++ b/benchmarks/ConvexPolyhedron.elm
@@ -1,0 +1,53 @@
+module ConvexPolyhedron exposing (main)
+
+import Benchmark exposing (..)
+import Benchmark.Runner exposing (BenchmarkProgram, program)
+import Math.Vector3 as Vec3 exposing (Vec3, vec3)
+import Physics.ConvexPolyhedron as ConvexPolyhedron exposing (ConvexPolyhedron)
+import Physics.OriginalConvexPolyhedron as OriginalConvexPolyhedron
+
+
+main : BenchmarkProgram
+main =
+    program suite
+
+
+suite : Benchmark
+suite =
+    let
+        sampleHull =
+            vec3 1 1 1
+                |> ConvexPolyhedron.fromBox
+
+        trivialVisitor : Vec3 -> Vec3 -> Int -> Int
+        trivialVisitor _ _ _ =
+            0
+    in
+        describe "ConvexPolyhedron"
+            [ benchmark "foldFaceNormals" <|
+                \_ ->
+                    ConvexPolyhedron.foldFaceNormals
+                        -- fold a function with minimal overhead
+                        trivialVisitor
+                        0
+                        sampleHull
+
+            -- compare the results of two benchmarks
+            , Benchmark.compare "foldFaceNormals"
+                "original parallel face arrays"
+                (\_ ->
+                    ConvexPolyhedron.foldFaceNormals
+                        -- fold a function with minimal overhead
+                        trivialVisitor
+                        0
+                        sampleHull
+                )
+                "unified face array"
+                (\_ ->
+                    OriginalConvexPolyhedron.foldFaceNormals
+                        -- fold a function with minimal overhead
+                        trivialVisitor
+                        0
+                        sampleHull
+                )
+            ]

--- a/benchmarks/elm-package.json
+++ b/benchmarks/elm-package.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.0.0",
+    "summary": "elm-physics benchmarking",
+    "repository": "https://github.com/w0rm/elm-physics",
+    "license": "BSD3",
+    "source-directories": [
+        "..",
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "Skinney/elm-array-exploration": "2.0.5 <= v < 3.0.0",
+        "BrianHicks/elm-benchmark": "2.0.3 <= v < 3.0.0",
+        "elm-community/linear-algebra": "3.1.1 <= v < 4.0.0",
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
Added a subdirectory with elm-package.json to enable future benchmarks. Included a sanity check benchmark taken from the benchmark library's documentation. Tweaked the repo LICENSE to allow the repo to include copies of individual open source files unambiguously under their own copyrights and license terms.