### PR TITLE
Define Face in ConvexPolyhedron to hold per-face data, integrate cached adjacentFaces.

### DIFF
--- a/benchmarks/ConvexPolyhedron.elm
+++ b/benchmarks/ConvexPolyhedron.elm
@@ -1,0 +1,53 @@
+module ConvexPolyhedron exposing (main)
+
+import Benchmark exposing (..)
+import Benchmark.Runner exposing (BenchmarkProgram, program)
+import Math.Vector3 as Vec3 exposing (Vec3, vec3)
+import Physics.ConvexPolyhedron as ConvexPolyhedron exposing (ConvexPolyhedron)
+import Physics.OriginalConvexPolyhedron as OriginalConvexPolyhedron
+
+
+main : BenchmarkProgram
+main =
+    program suite
+
+
+suite : Benchmark
+suite =
+    let
+        sampleHull =
+            vec3 1 1 1
+                |> ConvexPolyhedron.fromBox
+
+        trivialVisitor : Vec3 -> Vec3 -> Int -> Int
+        trivialVisitor _ _ _ =
+            0
+    in
+        describe "ConvexPolyhedron"
+            [ benchmark "foldFaceNormals" <|
+                \_ ->
+                    ConvexPolyhedron.foldFaceNormals
+                        -- fold a function with minimal overhead
+                        trivialVisitor
+                        0
+                        sampleHull
+
+            -- compare the results of two benchmarks
+            , Benchmark.compare "foldFaceNormals"
+                "original parallel face arrays"
+                (\_ ->
+                    ConvexPolyhedron.foldFaceNormals
+                        -- fold a function with minimal overhead
+                        trivialVisitor
+                        0
+                        sampleHull
+                )
+                "unified face array"
+                (\_ ->
+                    OriginalConvexPolyhedron.foldFaceNormals
+                        -- fold a function with minimal overhead
+                        trivialVisitor
+                        0
+                        sampleHull
+                )
+            ]

--- a/benchmarks/ConvexPolyhedron.elm
+++ b/benchmarks/ConvexPolyhedron.elm
@@ -4,7 +4,28 @@ import Benchmark exposing (..)
 import Benchmark.Runner exposing (BenchmarkProgram, program)
 import Math.Vector3 as Vec3 exposing (Vec3, vec3)
 import Physics.ConvexPolyhedron as ConvexPolyhedron exposing (ConvexPolyhedron)
-import Physics.OriginalConvexPolyhedron as OriginalConvexPolyhedron
+import Physics.Quaternion as Quaternion
+
+
+{- For a useful benchmark,
+   copy and rename an older baseline version of Physics/ConvexPolyhedron.elm
+   to Physics/OriginalConvexPolyhedron.elm and toggle the import below
+   from:
+
+      import Physics.ConvexPolyhedron as OriginalConvexPolyhedron
+
+    to:
+
+      import Physics.OriginalConvexPolyhedron as OriginalConvexPolyhedron
+
+    Switching it back to use the (current) ConvexPolyhedron.elm through the
+    OriginalConvexPolyhedron alias keeps obsolete or redundant code out of
+    the repo while the comparison benchmarks continue to be maintained and
+    built and run essentially as absolute non-comparison benchmarks until
+    they are needed again in another round of performance work.
+-}
+
+import Physics.ConvexPolyhedron as OriginalConvexPolyhedron
 
 
 main : BenchmarkProgram
@@ -19,22 +40,51 @@ suite =
             vec3 1 1 1
                 |> ConvexPolyhedron.fromBox
 
+        originalSampleHull =
+            vec3 1 1 1
+                |> OriginalConvexPolyhedron.fromBox
+
         trivialVisitor : Vec3 -> Vec3 -> Int -> Int
         trivialVisitor _ _ _ =
             0
+
+        sepNormal =
+            vec3 0 0 1
+
+        -- Move the box 0.45 units up
+        -- only 0.05 units of the box will be below plane z=0
+        transform =
+            { position = vec3 0 0 0.45
+            , quaternion = Quaternion.identity
+            }
+
+        -- points in the plane z
+        worldVertsB =
+            [ vec3 -1.0 -1.0 0
+            , vec3 -1.0 1.0 0
+            , vec3 1.0 1.0 0
+            , vec3 1.0 -1.0 0
+            ]
+
+        boxHull halfExtent =
+            ConvexPolyhedron.fromBox
+                (vec3 halfExtent halfExtent halfExtent)
+
+        originalBoxHull halfExtent =
+            OriginalConvexPolyhedron.fromBox
+                (vec3 halfExtent halfExtent halfExtent)
     in
         describe "ConvexPolyhedron"
-            [ benchmark "foldFaceNormals" <|
-                \_ ->
-                    ConvexPolyhedron.foldFaceNormals
+            [ Benchmark.compare "foldFaceNormals"
+                "baseline"
+                (\_ ->
+                    OriginalConvexPolyhedron.foldFaceNormals
                         -- fold a function with minimal overhead
                         trivialVisitor
                         0
-                        sampleHull
-
-            -- compare the results of two benchmarks
-            , Benchmark.compare "foldFaceNormals"
-                "original parallel face arrays"
+                        originalSampleHull
+                )
+                "latest code"
                 (\_ ->
                     ConvexPolyhedron.foldFaceNormals
                         -- fold a function with minimal overhead
@@ -42,12 +92,31 @@ suite =
                         0
                         sampleHull
                 )
-                "unified face array"
+
+            -- We will now clip a face in hullA that is closest to the
+            -- sepNormal against the points in worldVertsB.
+            -- We can expect to get back the 4 corners of the box hullA
+            -- penetrated 0.05 units into the plane worldVertsB we
+            -- constructed.
+            , Benchmark.compare "clipFaceAgainstHull"
+                "baseline"
                 (\_ ->
-                    OriginalConvexPolyhedron.foldFaceNormals
-                        -- fold a function with minimal overhead
-                        trivialVisitor
-                        0
-                        sampleHull
+                    OriginalConvexPolyhedron.clipFaceAgainstHull
+                        transform
+                        (originalBoxHull 0.5)
+                        sepNormal
+                        worldVertsB
+                        -100
+                        100
+                )
+                "latest code"
+                (\_ ->
+                    ConvexPolyhedron.clipFaceAgainstHull
+                        transform
+                        (boxHull 0.5)
+                        sepNormal
+                        worldVertsB
+                        -100
+                        100
                 )
             ]

--- a/benchmarks/elm-package.json
+++ b/benchmarks/elm-package.json
@@ -1,0 +1,19 @@
+{
+    "version": "1.0.0",
+    "summary": "elm-physics benchmarking",
+    "repository": "https://github.com/w0rm/elm-physics",
+    "license": "BSD3",
+    "source-directories": [
+        "..",
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "Skinney/elm-array-exploration": "2.0.5 <= v < 3.0.0",
+        "BrianHicks/elm-benchmark": "2.0.3 <= v < 3.0.0",
+        "elm-community/linear-algebra": "3.1.1 <= v < 4.0.0",
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
I also added a few benchmarks and tests and significantly reworked the adjacentFaces calculation. I'm not sure whether the original connectedFaces code, the new adjacentFaces code, or neither are actually correct as they are used in the library.  For example, how many adjacentFaces does the triangular face of an octohedron have? the 3, sharing its edges, or the 6 sharing its vertices? I've also made some small steps to ease constructing a test ConvexPolyhedron from just its vertices and faces. We should use this and build on this to validate and tune more behaviors for non-boxes. This work addresses issues #16 and #15 .