### PR TITLE
optimize sphereContact in face/edge/vertex order

### DIFF
--- a/Fixtures/ConvexPolyhedron.elm
+++ b/Fixtures/ConvexPolyhedron.elm
@@ -71,14 +71,14 @@ boxVertexIndices =
 
 octoVertices : Float -> Array Vec3
 octoVertices halfExtent =
-        [ (vec3 0 0 halfExtent)
-        , (vec3 0 halfExtent 0)
-        , (vec3 halfExtent 0 0)
-        , (vec3 -halfExtent 0 0)
-        , (vec3 0 0 -halfExtent)
-        , (vec3 0 -halfExtent 0)
-        ]
-            |> Array.fromList
+    [ (vec3 0 0 halfExtent)
+    , (vec3 0 halfExtent 0)
+    , (vec3 halfExtent 0 0)
+    , (vec3 -halfExtent 0 0)
+    , (vec3 0 0 -halfExtent)
+    , (vec3 0 -halfExtent 0)
+    ]
+        |> Array.fromList
 
 
 octoHull : Float -> ConvexPolyhedron.ConvexPolyhedron

--- a/Fixtures/NarrowPhase.elm
+++ b/Fixtures/NarrowPhase.elm
@@ -5,8 +5,8 @@ import Physics.Const as Const
 import Physics.ContactEquation as ContactEquation exposing (ContactEquation)
 
 
-sphereContactBoxPositions : Float -> Float -> List ( Vec3, List ContactEquation )
-sphereContactBoxPositions radius boxHalfExtent =
+sphereContactBoxPositions : Vec3 -> Float -> Float -> List ( Vec3, List ContactEquation )
+sphereContactBoxPositions center radius boxHalfExtent =
     let
         delta =
             3 * Const.precision
@@ -45,137 +45,137 @@ sphereContactBoxPositions radius boxHalfExtent =
     in
         -- Box positions and their resulting contacts:
         [ -- the 8 vertex contacts
-          ( (vec3 vertexDimension vertexDimension vertexDimension)
+          ( (vec3 vertexDimension vertexDimension vertexDimension) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt3 invSqrt3 invSqrt3), rj = (vec3 -boxHalfExtent -boxHalfExtent -boxHalfExtent) }
           )
-        , ( (vec3 (-vertexDimension) vertexDimension vertexDimension)
+        , ( (vec3 (-vertexDimension) vertexDimension vertexDimension) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt3 invSqrt3 invSqrt3), rj = (vec3 boxHalfExtent -boxHalfExtent -boxHalfExtent) }
           )
-        , ( (vec3 vertexDimension (-vertexDimension) vertexDimension)
+        , ( (vec3 vertexDimension (-vertexDimension) vertexDimension) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 -boxHalfExtent boxHalfExtent -boxHalfExtent) }
           )
-        , ( (vec3 (-vertexDimension) (-vertexDimension) vertexDimension)
+        , ( (vec3 (-vertexDimension) (-vertexDimension) vertexDimension) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 boxHalfExtent boxHalfExtent -boxHalfExtent) }
           )
-        , ( (vec3 vertexDimension vertexDimension (-vertexDimension))
+        , ( (vec3 vertexDimension vertexDimension (-vertexDimension)) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 -boxHalfExtent -boxHalfExtent boxHalfExtent) }
           )
-        , ( (vec3 (-vertexDimension) vertexDimension (-vertexDimension))
+        , ( (vec3 (-vertexDimension) vertexDimension (-vertexDimension)) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 boxHalfExtent -boxHalfExtent boxHalfExtent) }
           )
-        , ( (vec3 vertexDimension (-vertexDimension) (-vertexDimension))
+        , ( (vec3 vertexDimension (-vertexDimension) (-vertexDimension)) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 -boxHalfExtent boxHalfExtent boxHalfExtent) }
           )
-        , ( (vec3 (-vertexDimension) (-vertexDimension) (-vertexDimension))
+        , ( (vec3 (-vertexDimension) (-vertexDimension) (-vertexDimension)) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 boxHalfExtent boxHalfExtent boxHalfExtent) }
           )
 
         -- the 12 edge (midpoint) contacts
-        , ( (vec3 edgeDimension edgeDimension 0)
+        , ( (vec3 edgeDimension edgeDimension 0) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt2 invSqrt2 0), rj = (vec3 -boxHalfExtent -boxHalfExtent 0) }
           )
-        , ( (vec3 0 edgeDimension edgeDimension)
+        , ( (vec3 0 edgeDimension edgeDimension) |> Vec3.add center
           , ceq { ni = (vec3 0 invSqrt2 invSqrt2), rj = (vec3 0 -boxHalfExtent -boxHalfExtent) }
           )
-        , ( (vec3 edgeDimension 0 edgeDimension)
+        , ( (vec3 edgeDimension 0 edgeDimension) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt2 0 invSqrt2), rj = (vec3 -boxHalfExtent 0 -boxHalfExtent) }
           )
-        , ( (vec3 (-edgeDimension) edgeDimension 0)
+        , ( (vec3 (-edgeDimension) edgeDimension 0) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt2 invSqrt2 0), rj = (vec3 boxHalfExtent -boxHalfExtent 0) }
           )
-        , ( (vec3 0 (-edgeDimension) edgeDimension)
+        , ( (vec3 0 (-edgeDimension) edgeDimension) |> Vec3.add center
           , ceq { ni = (vec3 0 -invSqrt2 invSqrt2), rj = (vec3 0 boxHalfExtent -boxHalfExtent) }
           )
-        , ( (vec3 edgeDimension 0 (-edgeDimension))
+        , ( (vec3 edgeDimension 0 (-edgeDimension)) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt2 0 -invSqrt2), rj = (vec3 -boxHalfExtent 0 boxHalfExtent) }
           )
-        , ( (vec3 edgeDimension (-edgeDimension) 0)
+        , ( (vec3 edgeDimension (-edgeDimension) 0) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt2 -invSqrt2 0), rj = (vec3 -boxHalfExtent boxHalfExtent 0) }
           )
-        , ( (vec3 0 edgeDimension (-edgeDimension))
+        , ( (vec3 0 edgeDimension (-edgeDimension)) |> Vec3.add center
           , ceq { ni = (vec3 0 invSqrt2 -invSqrt2), rj = (vec3 0 -boxHalfExtent boxHalfExtent) }
           )
-        , ( (vec3 (-edgeDimension) 0 edgeDimension)
+        , ( (vec3 (-edgeDimension) 0 edgeDimension) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt2 0 invSqrt2), rj = (vec3 boxHalfExtent 0 -boxHalfExtent) }
           )
-        , ( (vec3 (-edgeDimension) (-edgeDimension) 0)
+        , ( (vec3 (-edgeDimension) (-edgeDimension) 0) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt2 -invSqrt2 0), rj = (vec3 boxHalfExtent boxHalfExtent 0) }
           )
-        , ( (vec3 0 (-edgeDimension) (-edgeDimension))
+        , ( (vec3 0 (-edgeDimension) (-edgeDimension)) |> Vec3.add center
           , ceq { ni = (vec3 0 -invSqrt2 -invSqrt2), rj = (vec3 0 boxHalfExtent boxHalfExtent) }
           )
-        , ( (vec3 (-edgeDimension) 0 (-edgeDimension))
+        , ( (vec3 (-edgeDimension) 0 (-edgeDimension)) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt2 0 -invSqrt2), rj = (vec3 boxHalfExtent 0 boxHalfExtent) }
           )
 
         -- the 6 face (center) contacts
-        , ( (vec3 faceDimension 0 0)
+        , ( (vec3 faceDimension 0 0) |> Vec3.add center
           , ceq { ni = (vec3 1 0 0), rj = (vec3 -boxHalfExtent 0 0) }
           )
-        , ( (vec3 0 faceDimension 0)
+        , ( (vec3 0 faceDimension 0) |> Vec3.add center
           , ceq { ni = (vec3 0 1 0), rj = (vec3 0 -boxHalfExtent 0) }
           )
-        , ( (vec3 0 0 faceDimension)
+        , ( (vec3 0 0 faceDimension) |> Vec3.add center
           , ceq { ni = (vec3 0 0 1), rj = (vec3 0 0 -boxHalfExtent) }
           )
-        , ( (vec3 (-faceDimension) 0 0)
+        , ( (vec3 (-faceDimension) 0 0) |> Vec3.add center
           , ceq { ni = (vec3 -1 0 0), rj = (vec3 boxHalfExtent 0 0) }
           )
-        , ( (vec3 0 (-faceDimension) 0)
+        , ( (vec3 0 (-faceDimension) 0) |> Vec3.add center
           , ceq { ni = (vec3 0 -1 0), rj = (vec3 0 boxHalfExtent 0) }
           )
-        , ( (vec3 0 0 (-faceDimension))
+        , ( (vec3 0 0 (-faceDimension)) |> Vec3.add center
           , ceq { ni = (vec3 0 0 -1), rj = (vec3 0 0 boxHalfExtent) }
           )
 
         -- 3 sample face contacts very near a vertex
-        , ( (vec3 nearEdgeOffset faceDimension nearEdgeOffset)
+        , ( (vec3 nearEdgeOffset faceDimension nearEdgeOffset) |> Vec3.add center
           , ceq { ni = (vec3 0 1 0), rj = (vec3 -nearEdgeOffset -boxHalfExtent -nearEdgeOffset) }
           )
-        , ( (vec3 (-faceDimension) nearEdgeOffset nearEdgeOffset)
+        , ( (vec3 (-faceDimension) nearEdgeOffset nearEdgeOffset) |> Vec3.add center
           , ceq { ni = (vec3 -1 0 0), rj = (vec3 boxHalfExtent -nearEdgeOffset -nearEdgeOffset) }
           )
-        , ( (vec3 nearEdgeOffset nearEdgeOffset (-faceDimension))
+        , ( (vec3 nearEdgeOffset nearEdgeOffset (-faceDimension)) |> Vec3.add center
           , ceq { ni = (vec3 0 0 -1), rj = (vec3 -nearEdgeOffset -nearEdgeOffset boxHalfExtent) }
           )
 
         -- 3 sample face contacts very near an edge (midpoint)
-        , ( (vec3 faceDimension nearEdgeOffset 0)
+        , ( (vec3 faceDimension nearEdgeOffset 0) |> Vec3.add center
           , ceq { ni = (vec3 1 0 0), rj = (vec3 -boxHalfExtent -nearEdgeOffset 0) }
           )
-        , ( (vec3 nearEdgeOffset 0 faceDimension)
+        , ( (vec3 nearEdgeOffset 0 faceDimension) |> Vec3.add center
           , ceq { ni = (vec3 0 0 1), rj = (vec3 -nearEdgeOffset 0 -boxHalfExtent) }
           )
-        , ( (vec3 0 (-faceDimension) nearEdgeOffset)
+        , ( (vec3 0 (-faceDimension) nearEdgeOffset) |> Vec3.add center
           , ceq { ni = (vec3 0 -1 0), rj = (vec3 0 boxHalfExtent -nearEdgeOffset) }
           )
 
         -- 3 sample edge contacts very near a vertex
-        , ( (vec3 edgeDimension edgeDimension nearEdgeOffset)
+        , ( (vec3 edgeDimension edgeDimension nearEdgeOffset) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt2 invSqrt2 0), rj = (vec3 -boxHalfExtent -boxHalfExtent -nearEdgeOffset) }
           )
-        , ( (vec3 nearEdgeOffset edgeDimension -edgeDimension)
+        , ( (vec3 nearEdgeOffset edgeDimension -edgeDimension) |> Vec3.add center
           , ceq { ni = (vec3 0 invSqrt2 -invSqrt2), rj = (vec3 -nearEdgeOffset -boxHalfExtent boxHalfExtent) }
           )
-        , ( (vec3 -edgeDimension -nearEdgeOffset edgeDimension)
+        , ( (vec3 -edgeDimension -nearEdgeOffset edgeDimension) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt2 0 invSqrt2), rj = (vec3 boxHalfExtent nearEdgeOffset -boxHalfExtent) }
           )
 
         -- 3 sample off-diagonal vertex contacts
-        , ( (vec3 vertexDimension (vertexDimension * offDiagonalFactor) (vertexDimension / offDiagonalFactor))
+        , ( (vec3 vertexDimension (vertexDimension * offDiagonalFactor) (vertexDimension / offDiagonalFactor)) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt3 invSqrt3 invSqrt3), rj = (vec3 -boxHalfExtent -boxHalfExtent -boxHalfExtent) }
           )
-        , ( (vec3 (-vertexDimension / offDiagonalFactor) (-vertexDimension) (vertexDimension * offDiagonalFactor))
+        , ( (vec3 (-vertexDimension / offDiagonalFactor) (-vertexDimension) (vertexDimension * offDiagonalFactor)) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 boxHalfExtent boxHalfExtent -boxHalfExtent) }
           )
-        , ( (vec3 (vertexDimension / offDiagonalFactor) (-vertexDimension * offDiagonalFactor) (-vertexDimension))
+        , ( (vec3 (vertexDimension / offDiagonalFactor) (-vertexDimension * offDiagonalFactor) (-vertexDimension)) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 -boxHalfExtent boxHalfExtent boxHalfExtent) }
           )
         ]
 
 
-sphereContactOctohedronPositions : Float -> Float -> List ( Vec3, List ContactEquation )
-sphereContactOctohedronPositions radius octoHalfExtent =
+sphereContactOctohedronPositions : Vec3 -> Float -> Float -> List ( Vec3, List ContactEquation )
+sphereContactOctohedronPositions center radius octoHalfExtent =
     let
         delta =
             3 * Const.precision
@@ -211,108 +211,108 @@ sphereContactOctohedronPositions radius octoHalfExtent =
     in
         [ -- Octohedron positions and their contacts
           -- 6 vertex contacts
-          ( (vec3 vertexDimension 0 0)
+          ( (vec3 vertexDimension 0 0) |> Vec3.add center
           , ceq { ni = (vec3 1 0 0), rj = (vec3 -octoHalfExtent 0 0) }
           )
-        , ( (vec3 0 vertexDimension 0)
+        , ( (vec3 0 vertexDimension 0) |> Vec3.add center
           , ceq { ni = (vec3 0 1 0), rj = (vec3 0 -octoHalfExtent 0) }
           )
-        , ( (vec3 0 0 vertexDimension)
+        , ( (vec3 0 0 vertexDimension) |> Vec3.add center
           , ceq { ni = (vec3 0 0 1), rj = (vec3 0 0 -octoHalfExtent) }
           )
-        , ( (vec3 0 0 (-vertexDimension))
+        , ( (vec3 0 0 (-vertexDimension)) |> Vec3.add center
           , ceq { ni = (vec3 0 0 -1), rj = (vec3 0 0 octoHalfExtent) }
           )
-        , ( (vec3 0 (-vertexDimension) 0)
+        , ( (vec3 0 (-vertexDimension) 0) |> Vec3.add center
           , ceq { ni = (vec3 0 -1 0), rj = (vec3 0 octoHalfExtent 0) }
           )
-        , ( (vec3 (-vertexDimension) 0 0)
+        , ( (vec3 (-vertexDimension) 0 0) |> Vec3.add center
           , ceq { ni = (vec3 -1 0 0), rj = (vec3 octoHalfExtent 0 0) }
           )
 
         -- 12 edge (midpoint) contacts
-        , ( (vec3 edgeDimension edgeDimension 0)
+        , ( (vec3 edgeDimension edgeDimension 0) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt2 invSqrt2 0), rj = (vec3 (-octoHalfExtent / 2) (-octoHalfExtent / 2) 0) }
           )
-        , ( (vec3 0 edgeDimension edgeDimension)
+        , ( (vec3 0 edgeDimension edgeDimension) |> Vec3.add center
           , ceq { ni = (vec3 0 invSqrt2 invSqrt2), rj = (vec3 0 (-octoHalfExtent / 2) (-octoHalfExtent / 2)) }
           )
-        , ( (vec3 edgeDimension 0 edgeDimension)
+        , ( (vec3 edgeDimension 0 edgeDimension) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt2 0 invSqrt2), rj = (vec3 (-octoHalfExtent / 2) 0 (-octoHalfExtent / 2)) }
           )
-        , ( (vec3 (-edgeDimension) edgeDimension 0)
+        , ( (vec3 (-edgeDimension) edgeDimension 0) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt2 invSqrt2 0), rj = (vec3 (octoHalfExtent / 2) (-octoHalfExtent / 2) 0) }
           )
-        , ( (vec3 0 (-edgeDimension) edgeDimension)
+        , ( (vec3 0 (-edgeDimension) edgeDimension) |> Vec3.add center
           , ceq { ni = (vec3 0 -invSqrt2 invSqrt2), rj = (vec3 0 (octoHalfExtent / 2) (-octoHalfExtent / 2)) }
           )
-        , ( (vec3 edgeDimension 0 (-edgeDimension))
+        , ( (vec3 edgeDimension 0 (-edgeDimension)) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt2 0 -invSqrt2), rj = (vec3 (-octoHalfExtent / 2) 0 (octoHalfExtent / 2)) }
           )
-        , ( (vec3 edgeDimension (-edgeDimension) 0)
+        , ( (vec3 edgeDimension (-edgeDimension) 0) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt2 -invSqrt2 0), rj = (vec3 (-octoHalfExtent / 2) (octoHalfExtent / 2) 0) }
           )
-        , ( (vec3 0 edgeDimension (-edgeDimension))
+        , ( (vec3 0 edgeDimension (-edgeDimension)) |> Vec3.add center
           , ceq { ni = (vec3 0 invSqrt2 -invSqrt2), rj = (vec3 0 (-octoHalfExtent / 2) (octoHalfExtent / 2)) }
           )
-        , ( (vec3 (-edgeDimension) 0 edgeDimension)
+        , ( (vec3 (-edgeDimension) 0 edgeDimension) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt2 0 invSqrt2), rj = (vec3 (octoHalfExtent / 2) 0 (-octoHalfExtent / 2)) }
           )
-        , ( (vec3 (-edgeDimension) (-edgeDimension) 0)
+        , ( (vec3 (-edgeDimension) (-edgeDimension) 0) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt2 -invSqrt2 0), rj = (vec3 (octoHalfExtent / 2) (octoHalfExtent / 2) 0) }
           )
-        , ( (vec3 0 (-edgeDimension) (-edgeDimension))
+        , ( (vec3 0 (-edgeDimension) (-edgeDimension)) |> Vec3.add center
           , ceq { ni = (vec3 0 -invSqrt2 -invSqrt2), rj = (vec3 0 (octoHalfExtent / 2) (octoHalfExtent / 2)) }
           )
-        , ( (vec3 (-edgeDimension) 0 (-edgeDimension))
+        , ( (vec3 (-edgeDimension) 0 (-edgeDimension)) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt2 0 -invSqrt2), rj = (vec3 (octoHalfExtent / 2) 0 (octoHalfExtent / 2)) }
           )
 
         -- 8 face center contacts
-        , ( (vec3 faceDimension faceDimension faceDimension)
+        , ( (vec3 faceDimension faceDimension faceDimension) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt3 invSqrt3 invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (-octoHalfExtent / 3) (-octoHalfExtent / 3)) }
           )
-        , ( (vec3 faceDimension faceDimension (-faceDimension))
+        , ( (vec3 faceDimension faceDimension (-faceDimension)) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (-octoHalfExtent / 3) (octoHalfExtent / 3)) }
           )
-        , ( (vec3 faceDimension (-faceDimension) faceDimension)
+        , ( (vec3 faceDimension (-faceDimension) faceDimension) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (octoHalfExtent / 3) (-octoHalfExtent / 3)) }
           )
-        , ( (vec3 faceDimension (-faceDimension) (-faceDimension))
+        , ( (vec3 faceDimension (-faceDimension) (-faceDimension)) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (octoHalfExtent / 3) (octoHalfExtent / 3)) }
           )
-        , ( (vec3 (-faceDimension) faceDimension faceDimension)
+        , ( (vec3 (-faceDimension) faceDimension faceDimension) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt3 invSqrt3 invSqrt3), rj = (vec3 (octoHalfExtent / 3) (-octoHalfExtent / 3) (-octoHalfExtent / 3)) }
           )
-        , ( (vec3 (-faceDimension) faceDimension (-faceDimension))
+        , ( (vec3 (-faceDimension) faceDimension (-faceDimension)) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 (octoHalfExtent / 3) (-octoHalfExtent / 3) (octoHalfExtent / 3)) }
           )
-        , ( (vec3 (-faceDimension) (-faceDimension) faceDimension)
+        , ( (vec3 (-faceDimension) (-faceDimension) faceDimension) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 (octoHalfExtent / 3) (octoHalfExtent / 3) (-octoHalfExtent / 3)) }
           )
-        , ( (vec3 (-faceDimension) (-faceDimension) (-faceDimension))
+        , ( (vec3 (-faceDimension) (-faceDimension) (-faceDimension)) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 (octoHalfExtent / 3) (octoHalfExtent / 3) (octoHalfExtent / 3)) }
           )
 
         -- 3 face (near vertex) contacts
-        , ( (vec3 (vertexDimension - delta) delta delta)
+        , ( (vec3 (vertexDimension - delta) delta delta) |> Vec3.add center
           , ceq { ni = (vec3 1 delta delta), rj = (vec3 -octoHalfExtent 0 0) }
           )
-        , ( (vec3 delta delta (vertexDimension - delta))
+        , ( (vec3 delta delta (vertexDimension - delta)) |> Vec3.add center
           , ceq { ni = (vec3 delta delta 1), rj = (vec3 0 0 -octoHalfExtent) }
           )
-        , ( (vec3 (delta - vertexDimension) delta delta)
+        , ( (vec3 (delta - vertexDimension) delta delta) |> Vec3.add center
           , ceq { ni = (vec3 -1 delta delta), rj = (vec3 octoHalfExtent 0 0) }
           )
 
         -- 3 face (near edge) contacts
-        , ( (vec3 (edgeDimension - delta) (edgeDimension - delta) delta)
+        , ( (vec3 (edgeDimension - delta) (edgeDimension - delta) delta) |> Vec3.add center
           , ceq { ni = (vec3 invSqrt2 invSqrt2 delta), rj = (vec3 (delta - octoHalfExtent / 2) (-octoHalfExtent / 2) 0) }
           )
-        , ( (vec3 delta (edgeDimension - delta) (edgeDimension - delta))
+        , ( (vec3 delta (edgeDimension - delta) (edgeDimension - delta)) |> Vec3.add center
           , ceq { ni = (vec3 delta invSqrt2 invSqrt2), rj = (vec3 0 (-octoHalfExtent / 2) (delta - octoHalfExtent / 2)) }
           )
-        , ( (vec3 (delta - edgeDimension) -delta (delta - edgeDimension))
+        , ( (vec3 (delta - edgeDimension) -delta (delta - edgeDimension)) |> Vec3.add center
           , ceq { ni = (vec3 -invSqrt2 -delta -invSqrt2), rj = (vec3 (octoHalfExtent / 2) 0 (octoHalfExtent / 2)) }
           )
         ]

--- a/Fixtures/NarrowPhase.elm
+++ b/Fixtures/NarrowPhase.elm
@@ -5,7 +5,7 @@ import Physics.Const as Const
 import Physics.ContactEquation as ContactEquation exposing (ContactEquation)
 
 
-sphereContactBoxPositions : Float -> Float -> List (Vec3, List ContactEquation)
+sphereContactBoxPositions : Float -> Float -> List ( Vec3, List ContactEquation )
 sphereContactBoxPositions radius boxHalfExtent =
     let
         delta =
@@ -25,6 +25,9 @@ sphereContactBoxPositions radius boxHalfExtent =
         vertexDimension =
             boxHalfExtent + radius / (sqrt 3) - Const.precision
 
+        offDiagonalFactor =
+            (vertexDimension + delta) / vertexDimension
+
         edgeDimension =
             boxHalfExtent + radius / (sqrt 2) - Const.precision
 
@@ -40,113 +43,138 @@ sphereContactBoxPositions radius boxHalfExtent =
         invSqrt2 =
             1 / (sqrt 2)
     in
-        -- Box positions and their resulting contacts:      
+        -- Box positions and their resulting contacts:
         [ -- the 8 vertex contacts
           ( (vec3 vertexDimension vertexDimension vertexDimension)
-            , ceq { ni = (vec3 invSqrt3 invSqrt3 invSqrt3), rj = (vec3 -boxHalfExtent -boxHalfExtent -boxHalfExtent) }
-            )
-          , ( (vec3 (-vertexDimension) vertexDimension vertexDimension)
-            , ceq { ni = (vec3 -invSqrt3 invSqrt3 invSqrt3), rj = (vec3 boxHalfExtent -boxHalfExtent -boxHalfExtent) }
-            )
-          , ( (vec3 vertexDimension (-vertexDimension) vertexDimension)
-            , ceq { ni = (vec3 invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 -boxHalfExtent boxHalfExtent -boxHalfExtent) }
-            )
-          , ( (vec3 (-vertexDimension) (-vertexDimension) vertexDimension)
-            , ceq { ni = (vec3 -invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 boxHalfExtent boxHalfExtent -boxHalfExtent) }
-            )
-          , ( (vec3 vertexDimension vertexDimension (-vertexDimension))
-            , ceq { ni = (vec3 invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 -boxHalfExtent -boxHalfExtent boxHalfExtent) }
-            )
-          , ( (vec3 (-vertexDimension) vertexDimension (-vertexDimension))
-            , ceq { ni = (vec3 -invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 boxHalfExtent -boxHalfExtent boxHalfExtent) }
-            )
-          , ( (vec3 vertexDimension (-vertexDimension) (-vertexDimension))
-            , ceq { ni = (vec3 invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 -boxHalfExtent boxHalfExtent boxHalfExtent) }
-            )
-          , ( (vec3 (-vertexDimension) (-vertexDimension) (-vertexDimension))
-            , ceq { ni = (vec3 -invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 boxHalfExtent boxHalfExtent boxHalfExtent) }
-            )
-          -- the 12 edge (midpoint) contacts
-          , ( (vec3 edgeDimension edgeDimension 0)
-            , ceq { ni = (vec3 invSqrt2 invSqrt2 0), rj = (vec3 -boxHalfExtent -boxHalfExtent 0) }
-            )
-          , ( (vec3 0 edgeDimension edgeDimension)
-            , ceq { ni = (vec3 0 invSqrt2 invSqrt2), rj = (vec3 0 -boxHalfExtent -boxHalfExtent) }
-            )
-          , ( (vec3 edgeDimension 0 edgeDimension)
-            , ceq { ni = (vec3 invSqrt2 0 invSqrt2), rj = (vec3 -boxHalfExtent 0 -boxHalfExtent) }
-            )
-          , ( (vec3 (-edgeDimension) edgeDimension 0)
-            , ceq { ni = (vec3 -invSqrt2 invSqrt2 0), rj = (vec3 boxHalfExtent -boxHalfExtent 0) }
-            )
-          , ( (vec3 0 (-edgeDimension) edgeDimension)
-            , ceq { ni = (vec3 0 -invSqrt2 invSqrt2), rj = (vec3 0 boxHalfExtent -boxHalfExtent) }
-            )
-          , ( (vec3 edgeDimension 0 (-edgeDimension))
-            , ceq { ni = (vec3 invSqrt2 0 -invSqrt2), rj = (vec3 -boxHalfExtent 0 boxHalfExtent) }
-            )
-          , ( (vec3 edgeDimension (-edgeDimension) 0)
-            , ceq { ni = (vec3 invSqrt2 -invSqrt2 0), rj = (vec3 -boxHalfExtent boxHalfExtent 0) }
-            )
-          , ( (vec3 0 edgeDimension (-edgeDimension))
-            , ceq { ni = (vec3 0 invSqrt2 -invSqrt2), rj = (vec3 0 -boxHalfExtent boxHalfExtent) }
-            )
-          , ( (vec3 (-edgeDimension) 0 edgeDimension)
-            , ceq { ni = (vec3 -invSqrt2 0 invSqrt2), rj = (vec3 boxHalfExtent 0 -boxHalfExtent) }
-            )
-          , ( (vec3 (-edgeDimension) (-edgeDimension) 0)
-            , ceq { ni = (vec3 -invSqrt2 -invSqrt2 0), rj = (vec3 boxHalfExtent boxHalfExtent 0) }
-            )
-          , ( (vec3 0 (-edgeDimension) (-edgeDimension))
-            , ceq { ni = (vec3 0 -invSqrt2 -invSqrt2), rj = (vec3 0 boxHalfExtent boxHalfExtent) }
-            )
-          , ( (vec3 (-edgeDimension) 0 (-edgeDimension))
-            , ceq { ni = (vec3 -invSqrt2 0 -invSqrt2), rj = (vec3 boxHalfExtent 0 boxHalfExtent) }
-            )
-          -- the 6 face (center) contacts
-          , ( (vec3 faceDimension 0 0)
-            , ceq { ni = (vec3 1 0 0), rj = (vec3 -boxHalfExtent 0 0) }
-            )
-          , ( (vec3 0 faceDimension 0)
-            , ceq { ni = (vec3 0 1 0), rj = (vec3 0 -boxHalfExtent 0) }
-            )
-          , ( (vec3 0 0 faceDimension)
-            , ceq { ni = (vec3 0 0 1), rj = (vec3 0 0 -boxHalfExtent) }
-            )
-          , ( (vec3 (-faceDimension) 0 0)
-            , ceq { ni = (vec3 -1 0 0), rj = (vec3 boxHalfExtent 0 0) }
-            )
-          , ( (vec3 0 (-faceDimension) 0)
-            , ceq { ni = (vec3 0 -1 0), rj = (vec3 0 boxHalfExtent 0) }
-            )
-          , ( (vec3 0 0 (-faceDimension))
-            , ceq { ni = (vec3 0 0 -1), rj = (vec3 0 0 boxHalfExtent) }
-            )
-          -- 3 sample face contacts very near a vertex
-          , ( (vec3 nearEdgeOffset faceDimension nearEdgeOffset)
-            , ceq { ni = (vec3 0 1 0), rj = (vec3 -nearEdgeOffset -boxHalfExtent -nearEdgeOffset) }
-            )
-          , ( (vec3 (-faceDimension) nearEdgeOffset nearEdgeOffset)
-            , ceq { ni = (vec3 -1 0 0), rj = (vec3 boxHalfExtent -nearEdgeOffset -nearEdgeOffset) }
-            )
-          , ( (vec3 nearEdgeOffset nearEdgeOffset (-faceDimension))
-                      , ceq { ni = (vec3 0 0 -1), rj = (vec3 -nearEdgeOffset -nearEdgeOffset boxHalfExtent) }
-            )
-          -- 3 sample face contacts very near an edge (midpoint)
-          , ( (vec3 faceDimension nearEdgeOffset 0)
-            , ceq { ni = (vec3 1 0 0), rj = (vec3 -boxHalfExtent -nearEdgeOffset 0) }
-            )
-          , ( (vec3 nearEdgeOffset 0 faceDimension)
-            , ceq { ni = (vec3 0 0 1), rj = (vec3 -nearEdgeOffset 0 -boxHalfExtent) }
-            )
-          , ( (vec3 0 (-faceDimension) nearEdgeOffset)
-            , ceq { ni = (vec3 0 -1 0), rj = (vec3 0 boxHalfExtent -nearEdgeOffset) }
-            )
-          ]
+          , ceq { ni = (vec3 invSqrt3 invSqrt3 invSqrt3), rj = (vec3 -boxHalfExtent -boxHalfExtent -boxHalfExtent) }
+          )
+        , ( (vec3 (-vertexDimension) vertexDimension vertexDimension)
+          , ceq { ni = (vec3 -invSqrt3 invSqrt3 invSqrt3), rj = (vec3 boxHalfExtent -boxHalfExtent -boxHalfExtent) }
+          )
+        , ( (vec3 vertexDimension (-vertexDimension) vertexDimension)
+          , ceq { ni = (vec3 invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 -boxHalfExtent boxHalfExtent -boxHalfExtent) }
+          )
+        , ( (vec3 (-vertexDimension) (-vertexDimension) vertexDimension)
+          , ceq { ni = (vec3 -invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 boxHalfExtent boxHalfExtent -boxHalfExtent) }
+          )
+        , ( (vec3 vertexDimension vertexDimension (-vertexDimension))
+          , ceq { ni = (vec3 invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 -boxHalfExtent -boxHalfExtent boxHalfExtent) }
+          )
+        , ( (vec3 (-vertexDimension) vertexDimension (-vertexDimension))
+          , ceq { ni = (vec3 -invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 boxHalfExtent -boxHalfExtent boxHalfExtent) }
+          )
+        , ( (vec3 vertexDimension (-vertexDimension) (-vertexDimension))
+          , ceq { ni = (vec3 invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 -boxHalfExtent boxHalfExtent boxHalfExtent) }
+          )
+        , ( (vec3 (-vertexDimension) (-vertexDimension) (-vertexDimension))
+          , ceq { ni = (vec3 -invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 boxHalfExtent boxHalfExtent boxHalfExtent) }
+          )
+
+        -- the 12 edge (midpoint) contacts
+        , ( (vec3 edgeDimension edgeDimension 0)
+          , ceq { ni = (vec3 invSqrt2 invSqrt2 0), rj = (vec3 -boxHalfExtent -boxHalfExtent 0) }
+          )
+        , ( (vec3 0 edgeDimension edgeDimension)
+          , ceq { ni = (vec3 0 invSqrt2 invSqrt2), rj = (vec3 0 -boxHalfExtent -boxHalfExtent) }
+          )
+        , ( (vec3 edgeDimension 0 edgeDimension)
+          , ceq { ni = (vec3 invSqrt2 0 invSqrt2), rj = (vec3 -boxHalfExtent 0 -boxHalfExtent) }
+          )
+        , ( (vec3 (-edgeDimension) edgeDimension 0)
+          , ceq { ni = (vec3 -invSqrt2 invSqrt2 0), rj = (vec3 boxHalfExtent -boxHalfExtent 0) }
+          )
+        , ( (vec3 0 (-edgeDimension) edgeDimension)
+          , ceq { ni = (vec3 0 -invSqrt2 invSqrt2), rj = (vec3 0 boxHalfExtent -boxHalfExtent) }
+          )
+        , ( (vec3 edgeDimension 0 (-edgeDimension))
+          , ceq { ni = (vec3 invSqrt2 0 -invSqrt2), rj = (vec3 -boxHalfExtent 0 boxHalfExtent) }
+          )
+        , ( (vec3 edgeDimension (-edgeDimension) 0)
+          , ceq { ni = (vec3 invSqrt2 -invSqrt2 0), rj = (vec3 -boxHalfExtent boxHalfExtent 0) }
+          )
+        , ( (vec3 0 edgeDimension (-edgeDimension))
+          , ceq { ni = (vec3 0 invSqrt2 -invSqrt2), rj = (vec3 0 -boxHalfExtent boxHalfExtent) }
+          )
+        , ( (vec3 (-edgeDimension) 0 edgeDimension)
+          , ceq { ni = (vec3 -invSqrt2 0 invSqrt2), rj = (vec3 boxHalfExtent 0 -boxHalfExtent) }
+          )
+        , ( (vec3 (-edgeDimension) (-edgeDimension) 0)
+          , ceq { ni = (vec3 -invSqrt2 -invSqrt2 0), rj = (vec3 boxHalfExtent boxHalfExtent 0) }
+          )
+        , ( (vec3 0 (-edgeDimension) (-edgeDimension))
+          , ceq { ni = (vec3 0 -invSqrt2 -invSqrt2), rj = (vec3 0 boxHalfExtent boxHalfExtent) }
+          )
+        , ( (vec3 (-edgeDimension) 0 (-edgeDimension))
+          , ceq { ni = (vec3 -invSqrt2 0 -invSqrt2), rj = (vec3 boxHalfExtent 0 boxHalfExtent) }
+          )
+
+        -- the 6 face (center) contacts
+        , ( (vec3 faceDimension 0 0)
+          , ceq { ni = (vec3 1 0 0), rj = (vec3 -boxHalfExtent 0 0) }
+          )
+        , ( (vec3 0 faceDimension 0)
+          , ceq { ni = (vec3 0 1 0), rj = (vec3 0 -boxHalfExtent 0) }
+          )
+        , ( (vec3 0 0 faceDimension)
+          , ceq { ni = (vec3 0 0 1), rj = (vec3 0 0 -boxHalfExtent) }
+          )
+        , ( (vec3 (-faceDimension) 0 0)
+          , ceq { ni = (vec3 -1 0 0), rj = (vec3 boxHalfExtent 0 0) }
+          )
+        , ( (vec3 0 (-faceDimension) 0)
+          , ceq { ni = (vec3 0 -1 0), rj = (vec3 0 boxHalfExtent 0) }
+          )
+        , ( (vec3 0 0 (-faceDimension))
+          , ceq { ni = (vec3 0 0 -1), rj = (vec3 0 0 boxHalfExtent) }
+          )
+
+        -- 3 sample face contacts very near a vertex
+        , ( (vec3 nearEdgeOffset faceDimension nearEdgeOffset)
+          , ceq { ni = (vec3 0 1 0), rj = (vec3 -nearEdgeOffset -boxHalfExtent -nearEdgeOffset) }
+          )
+        , ( (vec3 (-faceDimension) nearEdgeOffset nearEdgeOffset)
+          , ceq { ni = (vec3 -1 0 0), rj = (vec3 boxHalfExtent -nearEdgeOffset -nearEdgeOffset) }
+          )
+        , ( (vec3 nearEdgeOffset nearEdgeOffset (-faceDimension))
+          , ceq { ni = (vec3 0 0 -1), rj = (vec3 -nearEdgeOffset -nearEdgeOffset boxHalfExtent) }
+          )
+
+        -- 3 sample face contacts very near an edge (midpoint)
+        , ( (vec3 faceDimension nearEdgeOffset 0)
+          , ceq { ni = (vec3 1 0 0), rj = (vec3 -boxHalfExtent -nearEdgeOffset 0) }
+          )
+        , ( (vec3 nearEdgeOffset 0 faceDimension)
+          , ceq { ni = (vec3 0 0 1), rj = (vec3 -nearEdgeOffset 0 -boxHalfExtent) }
+          )
+        , ( (vec3 0 (-faceDimension) nearEdgeOffset)
+          , ceq { ni = (vec3 0 -1 0), rj = (vec3 0 boxHalfExtent -nearEdgeOffset) }
+          )
+
+        -- 3 sample edge contacts very near a vertex
+        , ( (vec3 edgeDimension edgeDimension nearEdgeOffset)
+          , ceq { ni = (vec3 invSqrt2 invSqrt2 0), rj = (vec3 -boxHalfExtent -boxHalfExtent -nearEdgeOffset) }
+          )
+        , ( (vec3 nearEdgeOffset edgeDimension -edgeDimension)
+          , ceq { ni = (vec3 0 invSqrt2 -invSqrt2), rj = (vec3 -nearEdgeOffset -boxHalfExtent boxHalfExtent) }
+          )
+        , ( (vec3 -edgeDimension -nearEdgeOffset edgeDimension)
+          , ceq { ni = (vec3 -invSqrt2 0 invSqrt2), rj = (vec3 boxHalfExtent nearEdgeOffset -boxHalfExtent) }
+          )
+
+        -- 3 sample off-diagonal vertex contacts
+        , ( (vec3 vertexDimension (vertexDimension * offDiagonalFactor) (vertexDimension / offDiagonalFactor))
+          , ceq { ni = (vec3 invSqrt3 invSqrt3 invSqrt3), rj = (vec3 -boxHalfExtent -boxHalfExtent -boxHalfExtent) }
+          )
+        , ( (vec3 (-vertexDimension / offDiagonalFactor) (-vertexDimension) (vertexDimension * offDiagonalFactor))
+          , ceq { ni = (vec3 -invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 boxHalfExtent boxHalfExtent -boxHalfExtent) }
+          )
+        , ( (vec3 (vertexDimension / offDiagonalFactor) (-vertexDimension * offDiagonalFactor) (-vertexDimension))
+          , ceq { ni = (vec3 invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 -boxHalfExtent boxHalfExtent boxHalfExtent) }
+          )
+        ]
 
 
-
-sphereContactOctohedronPositions : Float -> Float -> List (Vec3, List ContactEquation)
+sphereContactOctohedronPositions : Float -> Float -> List ( Vec3, List ContactEquation )
 sphereContactOctohedronPositions radius octoHalfExtent =
     let
         delta =
@@ -184,107 +212,110 @@ sphereContactOctohedronPositions radius octoHalfExtent =
         [ -- Octohedron positions and their contacts
           -- 6 vertex contacts
           ( (vec3 vertexDimension 0 0)
-            , ceq { ni = (vec3 1 0 0), rj = (vec3 -octoHalfExtent 0 0) }
-            )
-          , ( (vec3 0 vertexDimension 0)
-            , ceq { ni = (vec3 0 1 0), rj = (vec3 0 -octoHalfExtent 0) }
-            )
-          , ( (vec3 0 0 vertexDimension)
-            , ceq { ni = (vec3 0 0 1), rj = (vec3 0 0 -octoHalfExtent) }
-            )
-          , ( (vec3 0 0 (-vertexDimension))
-            , ceq { ni = (vec3 0 0 -1), rj = (vec3 0 0 octoHalfExtent) }
-            )
-          , ( (vec3 0 (-vertexDimension) 0)
-            , ceq { ni = (vec3 0 -1 0), rj = (vec3 0 octoHalfExtent 0) }
-            )
-          , ( (vec3 (-vertexDimension) 0 0)
-            , ceq { ni = (vec3 -1 0 0), rj = (vec3 octoHalfExtent 0 0) }
+          , ceq { ni = (vec3 1 0 0), rj = (vec3 -octoHalfExtent 0 0) }
+          )
+        , ( (vec3 0 vertexDimension 0)
+          , ceq { ni = (vec3 0 1 0), rj = (vec3 0 -octoHalfExtent 0) }
+          )
+        , ( (vec3 0 0 vertexDimension)
+          , ceq { ni = (vec3 0 0 1), rj = (vec3 0 0 -octoHalfExtent) }
+          )
+        , ( (vec3 0 0 (-vertexDimension))
+          , ceq { ni = (vec3 0 0 -1), rj = (vec3 0 0 octoHalfExtent) }
+          )
+        , ( (vec3 0 (-vertexDimension) 0)
+          , ceq { ni = (vec3 0 -1 0), rj = (vec3 0 octoHalfExtent 0) }
+          )
+        , ( (vec3 (-vertexDimension) 0 0)
+          , ceq { ni = (vec3 -1 0 0), rj = (vec3 octoHalfExtent 0 0) }
+          )
 
-            )
-          -- 12 edge (midpoint) contacts
-          , ( (vec3 edgeDimension edgeDimension 0)
-            , ceq { ni = (vec3 invSqrt2 invSqrt2 0), rj = (vec3 (-octoHalfExtent / 2) (-octoHalfExtent / 2) 0) }
-            )
-          , ( (vec3 0 edgeDimension edgeDimension)
-            , ceq { ni = (vec3 0 invSqrt2 invSqrt2), rj = (vec3 0 (-octoHalfExtent / 2) (-octoHalfExtent / 2)) }
-            )
-          , ( (vec3 edgeDimension 0 edgeDimension)
-            , ceq { ni = (vec3 invSqrt2 0 invSqrt2), rj = (vec3 (-octoHalfExtent / 2) 0 (-octoHalfExtent / 2)) }
-            )
-          , ( (vec3 (-edgeDimension) edgeDimension 0)
-            , ceq { ni = (vec3 -invSqrt2 invSqrt2 0), rj = (vec3 (octoHalfExtent / 2) (-octoHalfExtent / 2) 0) }
-            )
-          , ( (vec3 0 (-edgeDimension) edgeDimension)
-            , ceq { ni = (vec3 0 -invSqrt2 invSqrt2), rj = (vec3 0 (octoHalfExtent / 2) (-octoHalfExtent / 2)) }
-            )
-          , ( (vec3 edgeDimension 0 (-edgeDimension))
-            , ceq { ni = (vec3 invSqrt2 0 -invSqrt2), rj = (vec3 (-octoHalfExtent / 2) 0 (octoHalfExtent / 2)) }
-            )
-          , ( (vec3 edgeDimension (-edgeDimension) 0)
-            , ceq { ni = (vec3 invSqrt2 -invSqrt2 0), rj = (vec3 (-octoHalfExtent / 2) (octoHalfExtent / 2) 0) }
-            )
-          , ( (vec3 0 edgeDimension (-edgeDimension))
-            , ceq { ni = (vec3 0 invSqrt2 -invSqrt2), rj = (vec3 0 (-octoHalfExtent / 2) (octoHalfExtent / 2)) }
-            )
-          , ( (vec3 (-edgeDimension) 0 edgeDimension)
-            , ceq { ni = (vec3 -invSqrt2 0 invSqrt2), rj = (vec3 (octoHalfExtent / 2) 0 (-octoHalfExtent / 2)) }
-            )
-          , ( (vec3 (-edgeDimension) (-edgeDimension) 0)
-            , ceq { ni = (vec3 -invSqrt2 -invSqrt2 0), rj = (vec3 (octoHalfExtent / 2) (octoHalfExtent / 2) 0) }
-            )
-          , ( (vec3 0 (-edgeDimension) (-edgeDimension))
-            , ceq { ni = (vec3 0 -invSqrt2 -invSqrt2), rj = (vec3 0 (octoHalfExtent / 2) (octoHalfExtent / 2)) }
-            )
-          , ( (vec3 (-edgeDimension) 0 (-edgeDimension))
-            , ceq { ni = (vec3 -invSqrt2 0 -invSqrt2), rj = (vec3 (octoHalfExtent / 2) 0 (octoHalfExtent / 2)) }
-            )
-          -- 8 face center contacts
-          , ( (vec3 faceDimension faceDimension faceDimension)
-            , ceq { ni = (vec3 invSqrt3 invSqrt3 invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (-octoHalfExtent / 3) (-octoHalfExtent / 3)) }
-            )
-          , ( (vec3 faceDimension faceDimension (-faceDimension))
-            , ceq { ni = (vec3 invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (-octoHalfExtent / 3) (octoHalfExtent / 3)) }
-            )
-          , ( (vec3 faceDimension (-faceDimension) faceDimension)
-            , ceq { ni = (vec3 invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (octoHalfExtent / 3) (-octoHalfExtent / 3)) }
-            )
-          , ( (vec3 faceDimension (-faceDimension) (-faceDimension))
-            , ceq { ni = (vec3 invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (octoHalfExtent / 3) (octoHalfExtent / 3)) }
-            )
-          , ( (vec3 (-faceDimension) faceDimension faceDimension)
-            , ceq { ni = (vec3 -invSqrt3 invSqrt3 invSqrt3), rj = (vec3 (octoHalfExtent / 3) (-octoHalfExtent / 3) (-octoHalfExtent / 3)) }
-            )
-          , ( (vec3 (-faceDimension) faceDimension (-faceDimension))
-            , ceq { ni = (vec3 -invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 (octoHalfExtent / 3) (-octoHalfExtent / 3) (octoHalfExtent / 3)) }
-            )
-          , ( (vec3 (-faceDimension) (-faceDimension) faceDimension)
-            , ceq { ni = (vec3 -invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 (octoHalfExtent / 3) (octoHalfExtent / 3) (-octoHalfExtent / 3)) }
-            )
-          , ( (vec3 (-faceDimension) (-faceDimension) (-faceDimension))
-            , ceq { ni = (vec3 -invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 (octoHalfExtent / 3) (octoHalfExtent / 3) (octoHalfExtent / 3)) }
-            )
-          -- 3 face (near vertex) contacts
-          , ( (vec3 (vertexDimension - delta) delta delta)
-            , ceq { ni = (vec3 1 delta delta), rj = (vec3 -octoHalfExtent 0 0) }
-            )
-          , ( (vec3 delta delta (vertexDimension - delta))
-            , ceq { ni = (vec3 delta delta 1), rj = (vec3 0 0 -octoHalfExtent) }
-            )
-          , ( (vec3 (delta - vertexDimension) delta delta)
-            , ceq { ni = (vec3 -1 delta delta), rj = (vec3 octoHalfExtent 0 0) }
-            )
-          -- 3 face (near edge) contacts
-          , ( (vec3 (edgeDimension - delta) (edgeDimension - delta) delta)
-            , ceq { ni = (vec3 invSqrt2 invSqrt2 delta), rj = (vec3 (delta - octoHalfExtent / 2) (-octoHalfExtent / 2) 0) }
-            )
-          , ( (vec3 delta (edgeDimension - delta) (edgeDimension - delta))
-            , ceq { ni = (vec3 delta invSqrt2 invSqrt2), rj = (vec3 0 (-octoHalfExtent / 2) (delta - octoHalfExtent / 2)) }
-            )
-          , ( (vec3 (delta - edgeDimension) -delta (delta - edgeDimension))
-            , ceq { ni = (vec3 -invSqrt2 -delta -invSqrt2), rj = (vec3 (octoHalfExtent / 2) 0 (octoHalfExtent / 2)) }
-            )
-          ]
+        -- 12 edge (midpoint) contacts
+        , ( (vec3 edgeDimension edgeDimension 0)
+          , ceq { ni = (vec3 invSqrt2 invSqrt2 0), rj = (vec3 (-octoHalfExtent / 2) (-octoHalfExtent / 2) 0) }
+          )
+        , ( (vec3 0 edgeDimension edgeDimension)
+          , ceq { ni = (vec3 0 invSqrt2 invSqrt2), rj = (vec3 0 (-octoHalfExtent / 2) (-octoHalfExtent / 2)) }
+          )
+        , ( (vec3 edgeDimension 0 edgeDimension)
+          , ceq { ni = (vec3 invSqrt2 0 invSqrt2), rj = (vec3 (-octoHalfExtent / 2) 0 (-octoHalfExtent / 2)) }
+          )
+        , ( (vec3 (-edgeDimension) edgeDimension 0)
+          , ceq { ni = (vec3 -invSqrt2 invSqrt2 0), rj = (vec3 (octoHalfExtent / 2) (-octoHalfExtent / 2) 0) }
+          )
+        , ( (vec3 0 (-edgeDimension) edgeDimension)
+          , ceq { ni = (vec3 0 -invSqrt2 invSqrt2), rj = (vec3 0 (octoHalfExtent / 2) (-octoHalfExtent / 2)) }
+          )
+        , ( (vec3 edgeDimension 0 (-edgeDimension))
+          , ceq { ni = (vec3 invSqrt2 0 -invSqrt2), rj = (vec3 (-octoHalfExtent / 2) 0 (octoHalfExtent / 2)) }
+          )
+        , ( (vec3 edgeDimension (-edgeDimension) 0)
+          , ceq { ni = (vec3 invSqrt2 -invSqrt2 0), rj = (vec3 (-octoHalfExtent / 2) (octoHalfExtent / 2) 0) }
+          )
+        , ( (vec3 0 edgeDimension (-edgeDimension))
+          , ceq { ni = (vec3 0 invSqrt2 -invSqrt2), rj = (vec3 0 (-octoHalfExtent / 2) (octoHalfExtent / 2)) }
+          )
+        , ( (vec3 (-edgeDimension) 0 edgeDimension)
+          , ceq { ni = (vec3 -invSqrt2 0 invSqrt2), rj = (vec3 (octoHalfExtent / 2) 0 (-octoHalfExtent / 2)) }
+          )
+        , ( (vec3 (-edgeDimension) (-edgeDimension) 0)
+          , ceq { ni = (vec3 -invSqrt2 -invSqrt2 0), rj = (vec3 (octoHalfExtent / 2) (octoHalfExtent / 2) 0) }
+          )
+        , ( (vec3 0 (-edgeDimension) (-edgeDimension))
+          , ceq { ni = (vec3 0 -invSqrt2 -invSqrt2), rj = (vec3 0 (octoHalfExtent / 2) (octoHalfExtent / 2)) }
+          )
+        , ( (vec3 (-edgeDimension) 0 (-edgeDimension))
+          , ceq { ni = (vec3 -invSqrt2 0 -invSqrt2), rj = (vec3 (octoHalfExtent / 2) 0 (octoHalfExtent / 2)) }
+          )
+
+        -- 8 face center contacts
+        , ( (vec3 faceDimension faceDimension faceDimension)
+          , ceq { ni = (vec3 invSqrt3 invSqrt3 invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (-octoHalfExtent / 3) (-octoHalfExtent / 3)) }
+          )
+        , ( (vec3 faceDimension faceDimension (-faceDimension))
+          , ceq { ni = (vec3 invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (-octoHalfExtent / 3) (octoHalfExtent / 3)) }
+          )
+        , ( (vec3 faceDimension (-faceDimension) faceDimension)
+          , ceq { ni = (vec3 invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (octoHalfExtent / 3) (-octoHalfExtent / 3)) }
+          )
+        , ( (vec3 faceDimension (-faceDimension) (-faceDimension))
+          , ceq { ni = (vec3 invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 (-octoHalfExtent / 3) (octoHalfExtent / 3) (octoHalfExtent / 3)) }
+          )
+        , ( (vec3 (-faceDimension) faceDimension faceDimension)
+          , ceq { ni = (vec3 -invSqrt3 invSqrt3 invSqrt3), rj = (vec3 (octoHalfExtent / 3) (-octoHalfExtent / 3) (-octoHalfExtent / 3)) }
+          )
+        , ( (vec3 (-faceDimension) faceDimension (-faceDimension))
+          , ceq { ni = (vec3 -invSqrt3 invSqrt3 -invSqrt3), rj = (vec3 (octoHalfExtent / 3) (-octoHalfExtent / 3) (octoHalfExtent / 3)) }
+          )
+        , ( (vec3 (-faceDimension) (-faceDimension) faceDimension)
+          , ceq { ni = (vec3 -invSqrt3 -invSqrt3 invSqrt3), rj = (vec3 (octoHalfExtent / 3) (octoHalfExtent / 3) (-octoHalfExtent / 3)) }
+          )
+        , ( (vec3 (-faceDimension) (-faceDimension) (-faceDimension))
+          , ceq { ni = (vec3 -invSqrt3 -invSqrt3 -invSqrt3), rj = (vec3 (octoHalfExtent / 3) (octoHalfExtent / 3) (octoHalfExtent / 3)) }
+          )
+
+        -- 3 face (near vertex) contacts
+        , ( (vec3 (vertexDimension - delta) delta delta)
+          , ceq { ni = (vec3 1 delta delta), rj = (vec3 -octoHalfExtent 0 0) }
+          )
+        , ( (vec3 delta delta (vertexDimension - delta))
+          , ceq { ni = (vec3 delta delta 1), rj = (vec3 0 0 -octoHalfExtent) }
+          )
+        , ( (vec3 (delta - vertexDimension) delta delta)
+          , ceq { ni = (vec3 -1 delta delta), rj = (vec3 octoHalfExtent 0 0) }
+          )
+
+        -- 3 face (near edge) contacts
+        , ( (vec3 (edgeDimension - delta) (edgeDimension - delta) delta)
+          , ceq { ni = (vec3 invSqrt2 invSqrt2 delta), rj = (vec3 (delta - octoHalfExtent / 2) (-octoHalfExtent / 2) 0) }
+          )
+        , ( (vec3 delta (edgeDimension - delta) (edgeDimension - delta))
+          , ceq { ni = (vec3 delta invSqrt2 invSqrt2), rj = (vec3 0 (-octoHalfExtent / 2) (delta - octoHalfExtent / 2)) }
+          )
+        , ( (vec3 (delta - edgeDimension) -delta (delta - edgeDimension))
+          , ceq { ni = (vec3 -invSqrt2 -delta -invSqrt2), rj = (vec3 (octoHalfExtent / 2) 0 (octoHalfExtent / 2)) }
+          )
+        ]
 
 
 completeSphereContactEquation : Float -> { ni : Vec3, rj : Vec3 } -> List ContactEquation

--- a/Physics/NarrowPhase.elm
+++ b/Physics/NarrowPhase.elm
@@ -11,7 +11,7 @@ import Math.Vector3 as Vec3 exposing (Vec3)
 import Physics.Body as Body exposing (Body, BodyId)
 import Physics.Const as Const
 import Physics.ContactEquation as ContactEquation exposing (ContactEquation)
-import Physics.ConvexPolyhedron as ConvexPolyhedron exposing (ConvexPolyhedron, Face)
+import Physics.ConvexPolyhedron as ConvexPolyhedron exposing (ConvexPolyhedron)
 import Physics.Quaternion as Quaternion
 import Physics.Shape as Shape exposing (Shape(..))
 import Physics.Transform as Transform exposing (Transform)

--- a/benchmarks/NarrowPhase.elm
+++ b/benchmarks/NarrowPhase.elm
@@ -4,6 +4,7 @@ import Benchmark exposing (..)
 import Benchmark.Runner exposing (BenchmarkProgram, program)
 import Fixtures.ConvexPolyhedron as HullFixtures
 import Fixtures.NarrowPhase
+import Math.Vector3 as Vec3 exposing (Vec3, vec3)
 import Physics.NarrowPhase as NarrowPhase
 import Physics.Quaternion as Quaternion
 import Physics.Transform as Transform
@@ -38,6 +39,9 @@ main =
 suite : Benchmark
 suite =
     let
+        center =
+            vec3 0 0 7
+
         radius =
             5
 
@@ -51,7 +55,11 @@ suite =
             HullFixtures.originalBoxHull boxHalfExtent
 
         boxPositions =
-            Fixtures.NarrowPhase.sphereContactBoxPositions radius boxHalfExtent
+            Fixtures.NarrowPhase.sphereContactBoxPositions center radius boxHalfExtent
+                |> List.map Tuple.first
+
+        boxFarPositions =
+            Fixtures.NarrowPhase.sphereContactBoxPositions center (radius * 2) boxHalfExtent
                 |> List.map Tuple.first
 
         octoHalfExtent =
@@ -64,11 +72,15 @@ suite =
             HullFixtures.originalOctoHull octoHalfExtent
 
         octoPositions =
-            Fixtures.NarrowPhase.sphereContactOctohedronPositions radius octoHalfExtent
+            Fixtures.NarrowPhase.sphereContactOctohedronPositions center radius octoHalfExtent
+                |> List.map Tuple.first
+
+        octoFarPositions =
+            Fixtures.NarrowPhase.sphereContactOctohedronPositions center (radius * 2) octoHalfExtent
                 |> List.map Tuple.first
     in
         describe "NarrowPhase"
-            [ Benchmark.compare "addSphereConvexContacts"
+            [ Benchmark.compare "addSphereConvexContacts box"
                 "baseline"
                 (\_ ->
                     boxPositions
@@ -92,7 +104,48 @@ suite =
                         |> List.map
                             (\position ->
                                 NarrowPhase.addSphereConvexContacts
-                                    Transform.identity
+                                    { position = center
+                                    , quaternion = Quaternion.identity
+                                    }
+                                    radius
+                                    0
+                                    { position = position
+                                    , quaternion = Quaternion.identity
+                                    }
+                                    boxHull
+                                    1
+                                    []
+                            )
+                )
+            , Benchmark.compare "addSphereConvexContacts box fail"
+                "baseline"
+                (\_ ->
+                    boxFarPositions
+                        |> List.map
+                            (\position ->
+                                OriginalNarrowPhase.addSphereConvexContacts
+                                    { position = center
+                                    , quaternion = Quaternion.identity
+                                    }
+                                    radius
+                                    0
+                                    { position = position
+                                    , quaternion = Quaternion.identity
+                                    }
+                                    originalBoxHull
+                                    1
+                                    []
+                            )
+                )
+                "latest code"
+                (\_ ->
+                    boxFarPositions
+                        |> List.map
+                            (\position ->
+                                NarrowPhase.addSphereConvexContacts
+                                    { position = center
+                                    , quaternion = Quaternion.identity
+                                    }
                                     radius
                                     0
                                     { position = position
@@ -110,7 +163,9 @@ suite =
                         |> List.map
                             (\position ->
                                 OriginalNarrowPhase.addSphereConvexContacts
-                                    Transform.identity
+                                    { position = center
+                                    , quaternion = Quaternion.identity
+                                    }
                                     radius
                                     0
                                     { position = position
@@ -127,7 +182,48 @@ suite =
                         |> List.map
                             (\position ->
                                 NarrowPhase.addSphereConvexContacts
-                                    Transform.identity
+                                    { position = center
+                                    , quaternion = Quaternion.identity
+                                    }
+                                    radius
+                                    0
+                                    { position = position
+                                    , quaternion = Quaternion.identity
+                                    }
+                                    octoHull
+                                    1
+                                    []
+                            )
+                )
+            , Benchmark.compare "addSphereConvexContacts oct fail"
+                "baseline"
+                (\_ ->
+                    octoFarPositions
+                        |> List.map
+                            (\position ->
+                                OriginalNarrowPhase.addSphereConvexContacts
+                                    { position = center
+                                    , quaternion = Quaternion.identity
+                                    }
+                                    radius
+                                    0
+                                    { position = position
+                                    , quaternion = Quaternion.identity
+                                    }
+                                    originalOctoHull
+                                    1
+                                    []
+                            )
+                )
+                "latest code"
+                (\_ ->
+                    octoFarPositions
+                        |> List.map
+                            (\position ->
+                                NarrowPhase.addSphereConvexContacts
+                                    { position = center
+                                    , quaternion = Quaternion.identity
+                                    }
                                     radius
                                     0
                                     { position = position

--- a/tests/ConvexPolyhedron.elm
+++ b/tests/ConvexPolyhedron.elm
@@ -383,8 +383,8 @@ project =
         ]
 
 
-faceNormal : Test
-faceNormal =
+initFaceNormal : Test
+initFaceNormal =
     let
         boxNormals =
             [ vec3 0 0 -1
@@ -491,7 +491,7 @@ faceNormal =
                         |> Array.fromList
                 )
     in
-        describe "ConvexPolyhedron.faceNormal"
+        describe "ConvexPolyhedron.initFaceNormal"
             [ test "works for the box" <|
                 \_ ->
                     boxHull 1
@@ -500,7 +500,7 @@ faceNormal =
                                     |> Array.toList
                                     |> List.map
                                         (\{ vertexIndices } ->
-                                            ConvexPolyhedron.faceNormal vertexIndices vertices
+                                            ConvexPolyhedron.initFaceNormal vertexIndices vertices
                                         )
                            )
                         |> Expect.equal boxNormals
@@ -516,7 +516,7 @@ faceNormal =
                     xRotationRingSequence
                         |> toRightTriangles xyRightTriangle
                         |> List.map
-                            (ConvexPolyhedron.faceNormal faceIndices)
+                            (ConvexPolyhedron.initFaceNormal faceIndices)
                         |> expectListVec3WithinPrecision
                             xNormalRingSequence
             , test "works for a left-handed triangle flipped around the x axis" <|
@@ -524,7 +524,7 @@ faceNormal =
                     xRotationRingSequence
                         |> toRightTriangles xyRightTriangle
                         |> List.map
-                            (ConvexPolyhedron.faceNormal backFaceIndices)
+                            (ConvexPolyhedron.initFaceNormal backFaceIndices)
                         |> expectListVec3WithinPrecision
                             xAntiNormalRingSequence
             , test "works for a right-handed triangle flipped around the y axis" <|
@@ -532,7 +532,7 @@ faceNormal =
                     yRotationRingSequence
                         |> toRightTriangles yzRightTriangle
                         |> List.map
-                            (ConvexPolyhedron.faceNormal faceIndices)
+                            (ConvexPolyhedron.initFaceNormal faceIndices)
                         |> expectListVec3WithinPrecision
                             yNormalRingSequence
             , test "works for a left-handed triangle flipped around the y axis" <|
@@ -540,7 +540,7 @@ faceNormal =
                     yRotationRingSequence
                         |> toRightTriangles yzRightTriangle
                         |> List.map
-                            (ConvexPolyhedron.faceNormal backFaceIndices)
+                            (ConvexPolyhedron.initFaceNormal backFaceIndices)
                         |> expectListVec3WithinPrecision
                             yAntiNormalRingSequence
             , test "works for a right-handed triangle flipped around the z axis" <|
@@ -548,7 +548,7 @@ faceNormal =
                     zRotationRingSequence
                         |> toRightTriangles zxRightTriangle
                         |> List.map
-                            (ConvexPolyhedron.faceNormal faceIndices)
+                            (ConvexPolyhedron.initFaceNormal faceIndices)
                         |> expectListVec3WithinPrecision
                             zNormalRingSequence
             , test "works for a left-handed triangle flipped around the z axis" <|
@@ -556,7 +556,7 @@ faceNormal =
                     zRotationRingSequence
                         |> toRightTriangles zxRightTriangle
                         |> List.map
-                            (ConvexPolyhedron.faceNormal backFaceIndices)
+                            (ConvexPolyhedron.initFaceNormal backFaceIndices)
                         |> expectListVec3WithinPrecision
                             zAntiNormalRingSequence
             ]
@@ -609,17 +609,18 @@ listRingRotate offset ring =
             |> List.take resultLength
 
 
-uniqueEdges : Test
-uniqueEdges =
-    describe "ConvexPolyhedron.uniqueEdges"
+initUniqueEdges : Test
+initUniqueEdges =
+    describe "ConvexPolyhedron.initUniqueEdges"
         -- There are several valid representations of the same convex
         -- polyhedron, differing in the listed order of vertices and/or faces
         -- or in insignificant rounding errors in vertex values.
-        -- So, the implementation of uniqueEdges should be given some lattitude
-        -- in its resulting list of edges. ConvexPolyhedron.addFaceEdges does
-        -- most of the work of ConvexPolyhedron.uniqueEdges, and it can be
-        -- tested with seed values to get more deterministic results from
-        -- ConvexPolyhedrons even with varying equivalent representations.
+        -- So, the implementation of initUniqueEdges should be given some
+        -- lattitude in its resulting list of edges.
+        -- ConvexPolyhedron.addFaceEdges does most of the work of
+        -- ConvexPolyhedron.initUniqueEdges, and it can be tested with seed
+        -- values to get more deterministic results from ConvexPolyhedrons
+        -- even with varying equivalent representations.
         [ test "gives the correct number of edges for a box" <|
             \_ ->
                 boxHull 1
@@ -629,7 +630,7 @@ uniqueEdges =
 
         -- The square pyramid shape has fewer parallel edges than a box.
         -- The extent of parallel edges in a box was masking a bug discovered
-        -- in code review of addFaceEdges/uniqueEdges that would miss
+        -- in code review of addFaceEdges/initUniqueEdges that would miss
         -- some edges.
         , test "works for a square pyramid" <|
             \_ ->
@@ -657,23 +658,25 @@ addFaceEdges : Test
 addFaceEdges =
     describe "ConvexPolyhedron.addFaceEdges"
         -- Testing addFaceEdges avoids over-testing for exact results from
-        -- ConvexPolyhedron.uniqueEdges.
+        -- ConvexPolyhedron.initUniqueEdges.
         -- There are several valid representations of the same convex
         -- polyhedron, differing in the listed order of vertices and/or faces
         -- or in insignificant rounding errors in vertex values.
-        -- So, the implementation of uniqueEdges should be given some lattitude
-        -- in its resulting list of edges. ConvexPolyhedron.addFaceEdges does
-        -- most of the work of ConvexPolyhedron.uniqueEdges, and it can be
-        -- tested with seed values to get more deterministic results from
-        -- ConvexPolyhedrons even with varying equivalent representations.
+        -- So, the implementation of initUniqueEdges should be given some
+        -- lattitude in its resulting list of edges.
+        -- ConvexPolyhedron.addFaceEdges does most of the work of
+        -- ConvexPolyhedron.initUniqueEdges, and it can be tested with seed
+        -- values to get more deterministic results from ConvexPolyhedrons
+        -- even with varying equivalent representations.
         [ test "works for the box with positive seeds" <|
             \_ ->
                 let
                     -- Pre-calculated seeds are one way to get an exact
-                    -- normalized result. Members of the seed set are acceptable
-                    -- members of the result set. So long as the result-building
-                    -- process is non-destructive, the seeds should act as magnets
-                    -- for other valid results and should mask them in the final
+                    -- normalized result. Members of the seed set are
+                    -- acceptable members of the result set.
+                    -- So long as the result-building process is
+                    -- non-destructive, the seeds should act as magnets for
+                    -- other valid results and should mask them in the final
                     -- result.
                     fullSeedSet =
                         [ vec3 1 0 0
@@ -699,9 +702,9 @@ addFaceEdges =
         , test "works for the box with partial seeds" <|
             \_ ->
                 let
-                    -- A partial seed set should get filled out by the addition of
-                    -- complementary edges. This tests that the de-duping is not
-                    -- wildly over- or under- aggressive.
+                    -- A partial seed set should get filled out by the
+                    -- addition of complementary edges. This tests that the
+                    -- de-duping is not wildly over- or under- aggressive.
                     partialSeedSet =
                         [ vec3 -1 0 0
                         , vec3 0 0 1
@@ -713,9 +716,9 @@ addFaceEdges =
         , test "works for the box with different partial seeds" <|
             \_ ->
                 let
-                    -- A partial seed set should get filled out by the addition of
-                    -- complementary edges. This tests that the de-duping is not
-                    -- wildly over- or under- aggressive.
+                    -- A partial seed set should get filled out by the
+                    -- addition of complementary edges. This tests that the
+                    -- de-duping is not wildly over- or under- aggressive.
                     partialSeedSet =
                         [ vec3 0 0 1 ]
                 in
@@ -725,9 +728,9 @@ addFaceEdges =
         , test "works for the box with other different partial seeds" <|
             \_ ->
                 let
-                    -- A partial seed set should get filled out by the addition of
-                    -- complementary edges. This tests that the de-duping is not
-                    -- wildly over- or under- aggressive.
+                    -- A partial seed set should get filled out by the
+                    -- addition of complementary edges. This tests that the
+                    -- de-duping is not wildly over- or under- aggressive.
                     partialSeedSet =
                         [ vec3 0 1 0 ]
                 in
@@ -758,11 +761,11 @@ addFaceEdges =
                 let
                     -- Each invalid seed should simply linger in the result
                     -- with no effect on how (many) valid elements are added
-                    -- as complementary edges. This tests that de-duping is not
-                    -- overly aggressive in its matching.
+                    -- as complementary edges. This tests that de-duping is
+                    -- not overly aggressive in its matching.
                     -- Note: Some seeds use (Const.precision * 3.0) offsets to
-                    -- force values that are purposely not quite precise enough
-                    -- to match "exact" vertex values.
+                    -- force values that are purposely not quite precise
+                    -- enough to match "exact" vertex values.
                     -- These tests should work as well with non-exact vertices
                     -- except in a worst case scenario: we are ASSUMING that
                     -- any insignificant error terms in the vertex values are
@@ -782,7 +785,7 @@ addFaceEdges =
 
         -- The square pyramid shape has fewer parallel edges than a box.
         -- The extent of parallel edges in a box was masking a bug discovered
-        -- in code review of addFaceEdges/uniqueEdges that would miss
+        -- in code review of addFaceEdges/initUniqueEdges that would miss
         -- some edges.
         , test "works for a square pyramid" <|
             \_ ->
@@ -874,9 +877,9 @@ faceAdjacency =
 -- Test helper functions
 
 
-{-| Provide convenient test access to uniqueEdges based on the faces and
+{-| Provide convenient test access to initUniqueEdges based on the faces and
 vertices of an existing ConvexPolyhedron. There is no need for this in
-production, where uniqueEdges is called once at most per ConvexPolyhedron
+production, where initUniqueEdges is called once at most per ConvexPolyhedron
 BEFORE that ConvexPolyhedron is fully initialized, because its result gets
 cached in ConvexPolyhedron.edges.
 -}
@@ -886,17 +889,17 @@ uniqueEdgesOfConvexPolyhedron { vertices, faces } =
         |> Array.toList
         |> List.map .vertexIndices
         |> (\faceVertexIndices ->
-                ConvexPolyhedron.uniqueEdges faceVertexIndices vertices
+                ConvexPolyhedron.initUniqueEdges faceVertexIndices vertices
            )
 
 
 {-| This test helper function is intended as a more flexible variant of
-ConvexPolyhedron.uniqueEdges. Its differences from uniqueEdges are that it can
-be fed an initial list of "seed" edges and it operates on a pre-existing
-ConvexPolyhedron's vertices and faces.
+ConvexPolyhedron.initUniqueEdges. Its differences from initUniqueEdges are
+that it can be fed an initial list of "seed" edges and it operates on a
+pre-existing ConvexPolyhedron's vertices and faces.
 See the comment on uniqueEdgesOfConvexPolyhedron.
 These differences have no application in production.
-Keep this code in sync with any changes to ConvexPolyhedron.uniqueEdges.
+Keep this code in sync with any changes to ConvexPolyhedron.initUniqueEdges.
 -}
 addEdgesOfConvexPolyhedron : List Vec3 -> ConvexPolyhedron -> List Vec3
 addEdgesOfConvexPolyhedron seedEdges { vertices, faces } =
@@ -907,12 +910,14 @@ addEdgesOfConvexPolyhedron seedEdges { vertices, faces } =
             (ConvexPolyhedron.addFaceEdges vertices)
             seedEdges
 
+
 {-| Useful variant of addEdgesOfConvexPolyhedron that abstracts out the count
 for a less-detailed result.
 -}
 countEdgesOfConvexPolyhedron : List Vec3 -> ConvexPolyhedron -> Int
 countEdgesOfConvexPolyhedron seedEdges hull =
     List.length <| addEdgesOfConvexPolyhedron seedEdges hull
+
 
 
 -- Test data generators


### PR DESCRIPTION
The reordering had a moderate performance impact on the order of 10%. This improvement held true when I also optimized BOTH branches as follows:

Do most calculations in the sphere's world frame.
Focus on minimizing contact distance rather than maximizing contact penetration.
Retain more details from each phase to filter and tune the later phases.

These latter optimizations had much more of an impact on focused benchmarks (3X or more). They are also included in this changeset as they greatly simplify the new code.

The other good news is that these optimizations required no changes to the static representation of ConvexPolyhedron.
#