### PR TITLE
Use Array for solver bodies

### DIFF
--- a/src/Internal/World.elm
+++ b/src/Internal/World.elm
@@ -16,6 +16,7 @@ type Protected data
 
 type alias World data =
     { bodies : List (Body data)
+    , freeIds : List BodyId
     , nextBodyId : BodyId
     , gravity : Vec3
     }


### PR DESCRIPTION
Using Arrays really improves the performance. Before `getContacts` wasn't even a bottleneck, `solverStep` took more time because of `Dict.insert`.

<img width="916" alt="Screenshot 2019-04-07 at 08 54 14" src="https://user-images.githubusercontent.com/43472/55679865-f4089f80-5912-11e9-9d3a-11dda0809321.png">

After the update `solverStep` is faster than `getContacts`:

<img width="908" alt="Screenshot 2019-04-07 at 08 50 55" src="https://user-images.githubusercontent.com/43472/55679878-1a2e3f80-5913-11e9-8dc4-8497c410592c.png">


So now #24 actually makes sense!
