### PR TITLE
Perfcrastination

### DIFF
--- a/benchmarks/NarrowPhase.elm
+++ b/benchmarks/NarrowPhase.elm
@@ -18,25 +18,10 @@ import Benchmark.Runner exposing (BenchmarkProgram, program)
 import Fixtures.ConvexPolyhedron as HullFixtures
 import Fixtures.NarrowPhase
 import Internal.Body as Body exposing (Body)
-import Internal.NarrowPhase as NarrowPhase
+import Internal.NarrowPhase as NarrowPhase exposing (Order(..))
 import Internal.Quaternion as Quaternion
 import Internal.Transform as Transform
 import Internal.Vector3 as Vec3 exposing (Vec3, vec3)
-
-
-emptyBody : Body ()
-emptyBody =
-    Body.compound [] ()
-
-
-body1 : Body ()
-body1 =
-    { emptyBody | id = 0 }
-
-
-body2 : Body ()
-body2 =
-    { emptyBody | id = 1 }
 
 
 main : BenchmarkProgram
@@ -96,14 +81,13 @@ suite =
                         (\position ->
                             {- OriginalNarrowPhase.addSphereConvexContacts -}
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 Transform.identity
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 originalBoxHull
-                                body2
                                 []
                         )
             )
@@ -113,16 +97,15 @@ suite =
                     |> List.map
                         (\position ->
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 boxHull
-                                body2
                                 []
                         )
             )
@@ -134,16 +117,15 @@ suite =
                         (\position ->
                             {- OriginalNarrowPhase.addSphereConvexContacts -}
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 originalBoxHull
-                                body2
                                 []
                         )
             )
@@ -153,16 +135,15 @@ suite =
                     |> List.map
                         (\position ->
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 boxHull
-                                body2
                                 []
                         )
             )
@@ -174,16 +155,15 @@ suite =
                         (\position ->
                             {- OriginalNarrowPhase.addSphereConvexContacts -}
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 originalOctoHull
-                                body2
                                 []
                         )
             )
@@ -193,16 +173,15 @@ suite =
                     |> List.map
                         (\position ->
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 octoHull
-                                body2
                                 []
                         )
             )
@@ -214,16 +193,15 @@ suite =
                         (\position ->
                             {- OriginalNarrowPhase.addSphereConvexContacts -}
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 originalOctoHull
-                                body2
                                 []
                         )
             )
@@ -233,16 +211,15 @@ suite =
                     |> List.map
                         (\position ->
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 octoHull
-                                body2
                                 []
                         )
             )

--- a/src/Fixtures/NarrowPhase.elm
+++ b/src/Fixtures/NarrowPhase.elm
@@ -1,7 +1,5 @@
 module Fixtures.NarrowPhase exposing
-    ( body1
-    , body2
-    , completeSphereContactEquation
+    ( completeSphereContactEquation
     , sphereContactBoxPositions
     , sphereContactOctohedronPositions
     )
@@ -9,26 +7,11 @@ module Fixtures.NarrowPhase exposing
 import Internal.Body as Body exposing (Body)
 import Internal.Const as Const
 import Internal.Material as Material
-import Internal.SolverEquation exposing (ContactEquation)
+import Internal.NarrowPhase exposing (Contact)
 import Internal.Vector3 as Vec3 exposing (Vec3, vec3)
 
 
-emptyBody : Body ()
-emptyBody =
-    Body.compound [] ()
-
-
-body1 : Body ()
-body1 =
-    { emptyBody | id = 0 }
-
-
-body2 : Body ()
-body2 =
-    { emptyBody | id = 1 }
-
-
-sphereContactBoxPositions : Vec3 -> Float -> Float -> List ( Vec3, List (ContactEquation ()) )
+sphereContactBoxPositions : Vec3 -> Float -> Float -> List ( Vec3, List Contact )
 sphereContactBoxPositions center radius boxHalfExtent =
     let
         delta =
@@ -58,7 +41,7 @@ sphereContactBoxPositions center radius boxHalfExtent =
             boxHalfExtent + radius - Const.precision
 
         ceq vectors =
-            completeSphereContactEquation radius vectors
+            ( vectors.cj, completeSphereContactEquation radius vectors )
 
         invSqrt3 =
             1 / sqrt 3
@@ -68,136 +51,60 @@ sphereContactBoxPositions center radius boxHalfExtent =
     in
     -- Box positions and their resulting contacts:
     [ -- the 8 vertex contacts
-      ( vec3 vertexDimension vertexDimension vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt3 invSqrt3 invSqrt3, rj = vec3 -boxHalfExtent -boxHalfExtent -boxHalfExtent }
-      )
-    , ( vec3 -vertexDimension vertexDimension vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt3 invSqrt3 invSqrt3, rj = vec3 boxHalfExtent -boxHalfExtent -boxHalfExtent }
-      )
-    , ( vec3 vertexDimension -vertexDimension vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt3 -invSqrt3 invSqrt3, rj = vec3 -boxHalfExtent boxHalfExtent -boxHalfExtent }
-      )
-    , ( vec3 -vertexDimension -vertexDimension vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt3 -invSqrt3 invSqrt3, rj = vec3 boxHalfExtent boxHalfExtent -boxHalfExtent }
-      )
-    , ( vec3 vertexDimension vertexDimension -vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt3 invSqrt3 -invSqrt3, rj = vec3 -boxHalfExtent -boxHalfExtent boxHalfExtent }
-      )
-    , ( vec3 -vertexDimension vertexDimension -vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt3 invSqrt3 -invSqrt3, rj = vec3 boxHalfExtent -boxHalfExtent boxHalfExtent }
-      )
-    , ( vec3 vertexDimension -vertexDimension -vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt3 -invSqrt3 -invSqrt3, rj = vec3 -boxHalfExtent boxHalfExtent boxHalfExtent }
-      )
-    , ( vec3 -vertexDimension -vertexDimension -vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt3 -invSqrt3 -invSqrt3, rj = vec3 boxHalfExtent boxHalfExtent boxHalfExtent }
-      )
+      ceq { cj = vec3 vertexDimension vertexDimension vertexDimension |> Vec3.add center, ci = center, ni = vec3 invSqrt3 invSqrt3 invSqrt3, rj = vec3 -boxHalfExtent -boxHalfExtent -boxHalfExtent }
+    , ceq { cj = vec3 -vertexDimension vertexDimension vertexDimension |> Vec3.add center, ci = center, ni = vec3 -invSqrt3 invSqrt3 invSqrt3, rj = vec3 boxHalfExtent -boxHalfExtent -boxHalfExtent }
+    , ceq { cj = vec3 vertexDimension -vertexDimension vertexDimension |> Vec3.add center, ci = center, ni = vec3 invSqrt3 -invSqrt3 invSqrt3, rj = vec3 -boxHalfExtent boxHalfExtent -boxHalfExtent }
+    , ceq { cj = vec3 -vertexDimension -vertexDimension vertexDimension |> Vec3.add center, ci = center, ni = vec3 -invSqrt3 -invSqrt3 invSqrt3, rj = vec3 boxHalfExtent boxHalfExtent -boxHalfExtent }
+    , ceq { cj = vec3 vertexDimension vertexDimension -vertexDimension |> Vec3.add center, ci = center, ni = vec3 invSqrt3 invSqrt3 -invSqrt3, rj = vec3 -boxHalfExtent -boxHalfExtent boxHalfExtent }
+    , ceq { cj = vec3 -vertexDimension vertexDimension -vertexDimension |> Vec3.add center, ci = center, ni = vec3 -invSqrt3 invSqrt3 -invSqrt3, rj = vec3 boxHalfExtent -boxHalfExtent boxHalfExtent }
+    , ceq { cj = vec3 vertexDimension -vertexDimension -vertexDimension |> Vec3.add center, ci = center, ni = vec3 invSqrt3 -invSqrt3 -invSqrt3, rj = vec3 -boxHalfExtent boxHalfExtent boxHalfExtent }
+    , ceq { cj = vec3 -vertexDimension -vertexDimension -vertexDimension |> Vec3.add center, ci = center, ni = vec3 -invSqrt3 -invSqrt3 -invSqrt3, rj = vec3 boxHalfExtent boxHalfExtent boxHalfExtent }
 
     -- the 12 edge (midpoint) contacts
-    , ( vec3 edgeDimension edgeDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 invSqrt2 invSqrt2 0, rj = vec3 -boxHalfExtent -boxHalfExtent 0 }
-      )
-    , ( vec3 0 edgeDimension edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 0 invSqrt2 invSqrt2, rj = vec3 0 -boxHalfExtent -boxHalfExtent }
-      )
-    , ( vec3 edgeDimension 0 edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt2 0 invSqrt2, rj = vec3 -boxHalfExtent 0 -boxHalfExtent }
-      )
-    , ( vec3 -edgeDimension edgeDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt2 invSqrt2 0, rj = vec3 boxHalfExtent -boxHalfExtent 0 }
-      )
-    , ( vec3 0 -edgeDimension edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 0 -invSqrt2 invSqrt2, rj = vec3 0 boxHalfExtent -boxHalfExtent }
-      )
-    , ( vec3 edgeDimension 0 -edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt2 0 -invSqrt2, rj = vec3 -boxHalfExtent 0 boxHalfExtent }
-      )
-    , ( vec3 edgeDimension -edgeDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 invSqrt2 -invSqrt2 0, rj = vec3 -boxHalfExtent boxHalfExtent 0 }
-      )
-    , ( vec3 0 edgeDimension -edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 0 invSqrt2 -invSqrt2, rj = vec3 0 -boxHalfExtent boxHalfExtent }
-      )
-    , ( vec3 -edgeDimension 0 edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt2 0 invSqrt2, rj = vec3 boxHalfExtent 0 -boxHalfExtent }
-      )
-    , ( vec3 -edgeDimension -edgeDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt2 -invSqrt2 0, rj = vec3 boxHalfExtent boxHalfExtent 0 }
-      )
-    , ( vec3 0 -edgeDimension -edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 0 -invSqrt2 -invSqrt2, rj = vec3 0 boxHalfExtent boxHalfExtent }
-      )
-    , ( vec3 -edgeDimension 0 -edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt2 0 -invSqrt2, rj = vec3 boxHalfExtent 0 boxHalfExtent }
-      )
+    , ceq { cj = vec3 edgeDimension edgeDimension 0 |> Vec3.add center, ci = center, ni = vec3 invSqrt2 invSqrt2 0, rj = vec3 -boxHalfExtent -boxHalfExtent 0 }
+    , ceq { cj = vec3 0 edgeDimension edgeDimension |> Vec3.add center, ci = center, ni = vec3 0 invSqrt2 invSqrt2, rj = vec3 0 -boxHalfExtent -boxHalfExtent }
+    , ceq { cj = vec3 edgeDimension 0 edgeDimension |> Vec3.add center, ci = center, ni = vec3 invSqrt2 0 invSqrt2, rj = vec3 -boxHalfExtent 0 -boxHalfExtent }
+    , ceq { cj = vec3 -edgeDimension edgeDimension 0 |> Vec3.add center, ci = center, ni = vec3 -invSqrt2 invSqrt2 0, rj = vec3 boxHalfExtent -boxHalfExtent 0 }
+    , ceq { cj = vec3 0 -edgeDimension edgeDimension |> Vec3.add center, ci = center, ni = vec3 0 -invSqrt2 invSqrt2, rj = vec3 0 boxHalfExtent -boxHalfExtent }
+    , ceq { cj = vec3 edgeDimension 0 -edgeDimension |> Vec3.add center, ci = center, ni = vec3 invSqrt2 0 -invSqrt2, rj = vec3 -boxHalfExtent 0 boxHalfExtent }
+    , ceq { cj = vec3 edgeDimension -edgeDimension 0 |> Vec3.add center, ci = center, ni = vec3 invSqrt2 -invSqrt2 0, rj = vec3 -boxHalfExtent boxHalfExtent 0 }
+    , ceq { cj = vec3 0 edgeDimension -edgeDimension |> Vec3.add center, ci = center, ni = vec3 0 invSqrt2 -invSqrt2, rj = vec3 0 -boxHalfExtent boxHalfExtent }
+    , ceq { cj = vec3 -edgeDimension 0 edgeDimension |> Vec3.add center, ci = center, ni = vec3 -invSqrt2 0 invSqrt2, rj = vec3 boxHalfExtent 0 -boxHalfExtent }
+    , ceq { cj = vec3 -edgeDimension -edgeDimension 0 |> Vec3.add center, ci = center, ni = vec3 -invSqrt2 -invSqrt2 0, rj = vec3 boxHalfExtent boxHalfExtent 0 }
+    , ceq { cj = vec3 0 -edgeDimension -edgeDimension |> Vec3.add center, ci = center, ni = vec3 0 -invSqrt2 -invSqrt2, rj = vec3 0 boxHalfExtent boxHalfExtent }
+    , ceq { cj = vec3 -edgeDimension 0 -edgeDimension |> Vec3.add center, ci = center, ni = vec3 -invSqrt2 0 -invSqrt2, rj = vec3 boxHalfExtent 0 boxHalfExtent }
 
     -- the 6 face (center) contacts
-    , ( vec3 faceDimension 0 0 |> Vec3.add center
-      , ceq { ni = vec3 1 0 0, rj = vec3 -boxHalfExtent 0 0 }
-      )
-    , ( vec3 0 faceDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 0 1 0, rj = vec3 0 -boxHalfExtent 0 }
-      )
-    , ( vec3 0 0 faceDimension |> Vec3.add center
-      , ceq { ni = vec3 0 0 1, rj = vec3 0 0 -boxHalfExtent }
-      )
-    , ( vec3 -faceDimension 0 0 |> Vec3.add center
-      , ceq { ni = vec3 -1 0 0, rj = vec3 boxHalfExtent 0 0 }
-      )
-    , ( vec3 0 -faceDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 0 -1 0, rj = vec3 0 boxHalfExtent 0 }
-      )
-    , ( vec3 0 0 -faceDimension |> Vec3.add center
-      , ceq { ni = vec3 0 0 -1, rj = vec3 0 0 boxHalfExtent }
-      )
+    , ceq { cj = vec3 faceDimension 0 0 |> Vec3.add center, ci = center, ni = vec3 1 0 0, rj = vec3 -boxHalfExtent 0 0 }
+    , ceq { cj = vec3 0 faceDimension 0 |> Vec3.add center, ci = center, ni = vec3 0 1 0, rj = vec3 0 -boxHalfExtent 0 }
+    , ceq { cj = vec3 0 0 faceDimension |> Vec3.add center, ci = center, ni = vec3 0 0 1, rj = vec3 0 0 -boxHalfExtent }
+    , ceq { cj = vec3 -faceDimension 0 0 |> Vec3.add center, ci = center, ni = vec3 -1 0 0, rj = vec3 boxHalfExtent 0 0 }
+    , ceq { cj = vec3 0 -faceDimension 0 |> Vec3.add center, ci = center, ni = vec3 0 -1 0, rj = vec3 0 boxHalfExtent 0 }
+    , ceq { cj = vec3 0 0 -faceDimension |> Vec3.add center, ci = center, ni = vec3 0 0 -1, rj = vec3 0 0 boxHalfExtent }
 
     -- 3 sample face contacts very near a vertex
-    , ( vec3 nearEdgeOffset faceDimension nearEdgeOffset |> Vec3.add center
-      , ceq { ni = vec3 0 1 0, rj = vec3 -nearEdgeOffset -boxHalfExtent -nearEdgeOffset }
-      )
-    , ( vec3 -faceDimension nearEdgeOffset nearEdgeOffset |> Vec3.add center
-      , ceq { ni = vec3 -1 0 0, rj = vec3 boxHalfExtent -nearEdgeOffset -nearEdgeOffset }
-      )
-    , ( vec3 nearEdgeOffset nearEdgeOffset -faceDimension |> Vec3.add center
-      , ceq { ni = vec3 0 0 -1, rj = vec3 -nearEdgeOffset -nearEdgeOffset boxHalfExtent }
-      )
+    , ceq { cj = vec3 nearEdgeOffset faceDimension nearEdgeOffset |> Vec3.add center, ci = center, ni = vec3 0 1 0, rj = vec3 -nearEdgeOffset -boxHalfExtent -nearEdgeOffset }
+    , ceq { cj = vec3 -faceDimension nearEdgeOffset nearEdgeOffset |> Vec3.add center, ci = center, ni = vec3 -1 0 0, rj = vec3 boxHalfExtent -nearEdgeOffset -nearEdgeOffset }
+    , ceq { cj = vec3 nearEdgeOffset nearEdgeOffset -faceDimension |> Vec3.add center, ci = center, ni = vec3 0 0 -1, rj = vec3 -nearEdgeOffset -nearEdgeOffset boxHalfExtent }
 
     -- 3 sample face contacts very near an edge (midpoint)
-    , ( vec3 faceDimension nearEdgeOffset 0 |> Vec3.add center
-      , ceq { ni = vec3 1 0 0, rj = vec3 -boxHalfExtent -nearEdgeOffset 0 }
-      )
-    , ( vec3 nearEdgeOffset 0 faceDimension |> Vec3.add center
-      , ceq { ni = vec3 0 0 1, rj = vec3 -nearEdgeOffset 0 -boxHalfExtent }
-      )
-    , ( vec3 0 -faceDimension nearEdgeOffset |> Vec3.add center
-      , ceq { ni = vec3 0 -1 0, rj = vec3 0 boxHalfExtent -nearEdgeOffset }
-      )
+    , ceq { cj = vec3 faceDimension nearEdgeOffset 0 |> Vec3.add center, ci = center, ni = vec3 1 0 0, rj = vec3 -boxHalfExtent -nearEdgeOffset 0 }
+    , ceq { cj = vec3 nearEdgeOffset 0 faceDimension |> Vec3.add center, ci = center, ni = vec3 0 0 1, rj = vec3 -nearEdgeOffset 0 -boxHalfExtent }
+    , ceq { cj = vec3 0 -faceDimension nearEdgeOffset |> Vec3.add center, ci = center, ni = vec3 0 -1 0, rj = vec3 0 boxHalfExtent -nearEdgeOffset }
 
     -- 3 sample edge contacts very near a vertex
-    , ( vec3 edgeDimension edgeDimension nearEdgeOffset |> Vec3.add center
-      , ceq { ni = vec3 invSqrt2 invSqrt2 0, rj = vec3 -boxHalfExtent -boxHalfExtent -nearEdgeOffset }
-      )
-    , ( vec3 nearEdgeOffset edgeDimension -edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 0 invSqrt2 -invSqrt2, rj = vec3 -nearEdgeOffset -boxHalfExtent boxHalfExtent }
-      )
-    , ( vec3 -edgeDimension -nearEdgeOffset edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt2 0 invSqrt2, rj = vec3 boxHalfExtent nearEdgeOffset -boxHalfExtent }
-      )
+    , ceq { cj = vec3 edgeDimension edgeDimension nearEdgeOffset |> Vec3.add center, ci = center, ni = vec3 invSqrt2 invSqrt2 0, rj = vec3 -boxHalfExtent -boxHalfExtent -nearEdgeOffset }
+    , ceq { cj = vec3 nearEdgeOffset edgeDimension -edgeDimension |> Vec3.add center, ci = center, ni = vec3 0 invSqrt2 -invSqrt2, rj = vec3 -nearEdgeOffset -boxHalfExtent boxHalfExtent }
+    , ceq { cj = vec3 -edgeDimension -nearEdgeOffset edgeDimension |> Vec3.add center, ci = center, ni = vec3 -invSqrt2 0 invSqrt2, rj = vec3 boxHalfExtent nearEdgeOffset -boxHalfExtent }
 
     -- 3 sample off-diagonal vertex contacts
-    , ( vec3 vertexDimension (vertexDimension * offDiagonalFactor) (vertexDimension / offDiagonalFactor) |> Vec3.add center
-      , ceq { ni = vec3 invSqrt3 invSqrt3 invSqrt3, rj = vec3 -boxHalfExtent -boxHalfExtent -boxHalfExtent }
-      )
-    , ( vec3 (-vertexDimension / offDiagonalFactor) -vertexDimension (vertexDimension * offDiagonalFactor) |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt3 -invSqrt3 invSqrt3, rj = vec3 boxHalfExtent boxHalfExtent -boxHalfExtent }
-      )
-    , ( vec3 (vertexDimension / offDiagonalFactor) (-vertexDimension * offDiagonalFactor) -vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt3 -invSqrt3 -invSqrt3, rj = vec3 -boxHalfExtent boxHalfExtent boxHalfExtent }
-      )
+    , ceq { cj = vec3 vertexDimension (vertexDimension * offDiagonalFactor) (vertexDimension / offDiagonalFactor) |> Vec3.add center, ci = center, ni = vec3 invSqrt3 invSqrt3 invSqrt3, rj = vec3 -boxHalfExtent -boxHalfExtent -boxHalfExtent }
+    , ceq { cj = vec3 (-vertexDimension / offDiagonalFactor) -vertexDimension (vertexDimension * offDiagonalFactor) |> Vec3.add center, ci = center, ni = vec3 -invSqrt3 -invSqrt3 invSqrt3, rj = vec3 boxHalfExtent boxHalfExtent -boxHalfExtent }
+    , ceq { cj = vec3 (vertexDimension / offDiagonalFactor) (-vertexDimension * offDiagonalFactor) -vertexDimension |> Vec3.add center, ci = center, ni = vec3 invSqrt3 -invSqrt3 -invSqrt3, rj = vec3 -boxHalfExtent boxHalfExtent boxHalfExtent }
     ]
 
 
-sphereContactOctohedronPositions : Vec3 -> Float -> Float -> List ( Vec3, List (ContactEquation ()) )
+sphereContactOctohedronPositions : Vec3 -> Float -> Float -> List ( Vec3, List Contact )
 sphereContactOctohedronPositions center radius octoHalfExtent =
     let
         delta =
@@ -224,7 +131,7 @@ sphereContactOctohedronPositions center radius octoHalfExtent =
             octoHalfExtent / 3 + radius / sqrt 3 - Const.precision
 
         ceq vectors =
-            completeSphereContactEquation radius vectors
+            ( vectors.cj, completeSphereContactEquation radius vectors )
 
         invSqrt3 =
             1 / sqrt 3
@@ -234,120 +141,53 @@ sphereContactOctohedronPositions center radius octoHalfExtent =
     in
     [ -- Octohedron positions and their contacts
       -- 6 vertex contacts
-      ( vec3 vertexDimension 0 0 |> Vec3.add center
-      , ceq { ni = vec3 1 0 0, rj = vec3 -octoHalfExtent 0 0 }
-      )
-    , ( vec3 0 vertexDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 0 1 0, rj = vec3 0 -octoHalfExtent 0 }
-      )
-    , ( vec3 0 0 vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 0 0 1, rj = vec3 0 0 -octoHalfExtent }
-      )
-    , ( vec3 0 0 -vertexDimension |> Vec3.add center
-      , ceq { ni = vec3 0 0 -1, rj = vec3 0 0 octoHalfExtent }
-      )
-    , ( vec3 0 -vertexDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 0 -1 0, rj = vec3 0 octoHalfExtent 0 }
-      )
-    , ( vec3 -vertexDimension 0 0 |> Vec3.add center
-      , ceq { ni = vec3 -1 0 0, rj = vec3 octoHalfExtent 0 0 }
-      )
+      ceq { ci = center, cj = vec3 vertexDimension 0 0 |> Vec3.add center, ni = vec3 1 0 0, rj = vec3 -octoHalfExtent 0 0 }
+    , ceq { ci = center, cj = vec3 0 vertexDimension 0 |> Vec3.add center, ni = vec3 0 1 0, rj = vec3 0 -octoHalfExtent 0 }
+    , ceq { ci = center, cj = vec3 0 0 vertexDimension |> Vec3.add center, ni = vec3 0 0 1, rj = vec3 0 0 -octoHalfExtent }
+    , ceq { ci = center, cj = vec3 0 0 -vertexDimension |> Vec3.add center, ni = vec3 0 0 -1, rj = vec3 0 0 octoHalfExtent }
+    , ceq { ci = center, cj = vec3 0 -vertexDimension 0 |> Vec3.add center, ni = vec3 0 -1 0, rj = vec3 0 octoHalfExtent 0 }
+    , ceq { ci = center, cj = vec3 -vertexDimension 0 0 |> Vec3.add center, ni = vec3 -1 0 0, rj = vec3 octoHalfExtent 0 0 }
 
     -- 12 edge (midpoint) contacts
-    , ( vec3 edgeDimension edgeDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 invSqrt2 invSqrt2 0, rj = vec3 (-octoHalfExtent / 2) (-octoHalfExtent / 2) 0 }
-      )
-    , ( vec3 0 edgeDimension edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 0 invSqrt2 invSqrt2, rj = vec3 0 (-octoHalfExtent / 2) (-octoHalfExtent / 2) }
-      )
-    , ( vec3 edgeDimension 0 edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt2 0 invSqrt2, rj = vec3 (-octoHalfExtent / 2) 0 (-octoHalfExtent / 2) }
-      )
-    , ( vec3 -edgeDimension edgeDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt2 invSqrt2 0, rj = vec3 (octoHalfExtent / 2) (-octoHalfExtent / 2) 0 }
-      )
-    , ( vec3 0 -edgeDimension edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 0 -invSqrt2 invSqrt2, rj = vec3 0 (octoHalfExtent / 2) (-octoHalfExtent / 2) }
-      )
-    , ( vec3 edgeDimension 0 -edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt2 0 -invSqrt2, rj = vec3 (-octoHalfExtent / 2) 0 (octoHalfExtent / 2) }
-      )
-    , ( vec3 edgeDimension -edgeDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 invSqrt2 -invSqrt2 0, rj = vec3 (-octoHalfExtent / 2) (octoHalfExtent / 2) 0 }
-      )
-    , ( vec3 0 edgeDimension -edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 0 invSqrt2 -invSqrt2, rj = vec3 0 (-octoHalfExtent / 2) (octoHalfExtent / 2) }
-      )
-    , ( vec3 -edgeDimension 0 edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt2 0 invSqrt2, rj = vec3 (octoHalfExtent / 2) 0 (-octoHalfExtent / 2) }
-      )
-    , ( vec3 -edgeDimension -edgeDimension 0 |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt2 -invSqrt2 0, rj = vec3 (octoHalfExtent / 2) (octoHalfExtent / 2) 0 }
-      )
-    , ( vec3 0 -edgeDimension -edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 0 -invSqrt2 -invSqrt2, rj = vec3 0 (octoHalfExtent / 2) (octoHalfExtent / 2) }
-      )
-    , ( vec3 -edgeDimension 0 -edgeDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt2 0 -invSqrt2, rj = vec3 (octoHalfExtent / 2) 0 (octoHalfExtent / 2) }
-      )
+    , ceq { ci = center, cj = vec3 edgeDimension edgeDimension 0 |> Vec3.add center, ni = vec3 invSqrt2 invSqrt2 0, rj = vec3 (-octoHalfExtent / 2) (-octoHalfExtent / 2) 0 }
+    , ceq { ci = center, cj = vec3 0 edgeDimension edgeDimension |> Vec3.add center, ni = vec3 0 invSqrt2 invSqrt2, rj = vec3 0 (-octoHalfExtent / 2) (-octoHalfExtent / 2) }
+    , ceq { ci = center, cj = vec3 edgeDimension 0 edgeDimension |> Vec3.add center, ni = vec3 invSqrt2 0 invSqrt2, rj = vec3 (-octoHalfExtent / 2) 0 (-octoHalfExtent / 2) }
+    , ceq { ci = center, cj = vec3 -edgeDimension edgeDimension 0 |> Vec3.add center, ni = vec3 -invSqrt2 invSqrt2 0, rj = vec3 (octoHalfExtent / 2) (-octoHalfExtent / 2) 0 }
+    , ceq { ci = center, cj = vec3 0 -edgeDimension edgeDimension |> Vec3.add center, ni = vec3 0 -invSqrt2 invSqrt2, rj = vec3 0 (octoHalfExtent / 2) (-octoHalfExtent / 2) }
+    , ceq { ci = center, cj = vec3 edgeDimension 0 -edgeDimension |> Vec3.add center, ni = vec3 invSqrt2 0 -invSqrt2, rj = vec3 (-octoHalfExtent / 2) 0 (octoHalfExtent / 2) }
+    , ceq { ci = center, cj = vec3 edgeDimension -edgeDimension 0 |> Vec3.add center, ni = vec3 invSqrt2 -invSqrt2 0, rj = vec3 (-octoHalfExtent / 2) (octoHalfExtent / 2) 0 }
+    , ceq { ci = center, cj = vec3 0 edgeDimension -edgeDimension |> Vec3.add center, ni = vec3 0 invSqrt2 -invSqrt2, rj = vec3 0 (-octoHalfExtent / 2) (octoHalfExtent / 2) }
+    , ceq { ci = center, cj = vec3 -edgeDimension 0 edgeDimension |> Vec3.add center, ni = vec3 -invSqrt2 0 invSqrt2, rj = vec3 (octoHalfExtent / 2) 0 (-octoHalfExtent / 2) }
+    , ceq { ci = center, cj = vec3 -edgeDimension -edgeDimension 0 |> Vec3.add center, ni = vec3 -invSqrt2 -invSqrt2 0, rj = vec3 (octoHalfExtent / 2) (octoHalfExtent / 2) 0 }
+    , ceq { ci = center, cj = vec3 0 -edgeDimension -edgeDimension |> Vec3.add center, ni = vec3 0 -invSqrt2 -invSqrt2, rj = vec3 0 (octoHalfExtent / 2) (octoHalfExtent / 2) }
+    , ceq { ci = center, cj = vec3 -edgeDimension 0 -edgeDimension |> Vec3.add center, ni = vec3 -invSqrt2 0 -invSqrt2, rj = vec3 (octoHalfExtent / 2) 0 (octoHalfExtent / 2) }
 
     -- 8 face center contacts
-    , ( vec3 faceDimension faceDimension faceDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt3 invSqrt3 invSqrt3, rj = vec3 (-octoHalfExtent / 3) (-octoHalfExtent / 3) (-octoHalfExtent / 3) }
-      )
-    , ( vec3 faceDimension faceDimension -faceDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt3 invSqrt3 -invSqrt3, rj = vec3 (-octoHalfExtent / 3) (-octoHalfExtent / 3) (octoHalfExtent / 3) }
-      )
-    , ( vec3 faceDimension -faceDimension faceDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt3 -invSqrt3 invSqrt3, rj = vec3 (-octoHalfExtent / 3) (octoHalfExtent / 3) (-octoHalfExtent / 3) }
-      )
-    , ( vec3 faceDimension -faceDimension -faceDimension |> Vec3.add center
-      , ceq { ni = vec3 invSqrt3 -invSqrt3 -invSqrt3, rj = vec3 (-octoHalfExtent / 3) (octoHalfExtent / 3) (octoHalfExtent / 3) }
-      )
-    , ( vec3 -faceDimension faceDimension faceDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt3 invSqrt3 invSqrt3, rj = vec3 (octoHalfExtent / 3) (-octoHalfExtent / 3) (-octoHalfExtent / 3) }
-      )
-    , ( vec3 -faceDimension faceDimension -faceDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt3 invSqrt3 -invSqrt3, rj = vec3 (octoHalfExtent / 3) (-octoHalfExtent / 3) (octoHalfExtent / 3) }
-      )
-    , ( vec3 -faceDimension -faceDimension faceDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt3 -invSqrt3 invSqrt3, rj = vec3 (octoHalfExtent / 3) (octoHalfExtent / 3) (-octoHalfExtent / 3) }
-      )
-    , ( vec3 -faceDimension -faceDimension -faceDimension |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt3 -invSqrt3 -invSqrt3, rj = vec3 (octoHalfExtent / 3) (octoHalfExtent / 3) (octoHalfExtent / 3) }
-      )
+    , ceq { ci = center, cj = vec3 faceDimension faceDimension faceDimension |> Vec3.add center, ni = vec3 invSqrt3 invSqrt3 invSqrt3, rj = vec3 (-octoHalfExtent / 3) (-octoHalfExtent / 3) (-octoHalfExtent / 3) }
+    , ceq { ci = center, cj = vec3 faceDimension faceDimension -faceDimension |> Vec3.add center, ni = vec3 invSqrt3 invSqrt3 -invSqrt3, rj = vec3 (-octoHalfExtent / 3) (-octoHalfExtent / 3) (octoHalfExtent / 3) }
+    , ceq { ci = center, cj = vec3 faceDimension -faceDimension faceDimension |> Vec3.add center, ni = vec3 invSqrt3 -invSqrt3 invSqrt3, rj = vec3 (-octoHalfExtent / 3) (octoHalfExtent / 3) (-octoHalfExtent / 3) }
+    , ceq { ci = center, cj = vec3 faceDimension -faceDimension -faceDimension |> Vec3.add center, ni = vec3 invSqrt3 -invSqrt3 -invSqrt3, rj = vec3 (-octoHalfExtent / 3) (octoHalfExtent / 3) (octoHalfExtent / 3) }
+    , ceq { ci = center, cj = vec3 -faceDimension faceDimension faceDimension |> Vec3.add center, ni = vec3 -invSqrt3 invSqrt3 invSqrt3, rj = vec3 (octoHalfExtent / 3) (-octoHalfExtent / 3) (-octoHalfExtent / 3) }
+    , ceq { ci = center, cj = vec3 -faceDimension faceDimension -faceDimension |> Vec3.add center, ni = vec3 -invSqrt3 invSqrt3 -invSqrt3, rj = vec3 (octoHalfExtent / 3) (-octoHalfExtent / 3) (octoHalfExtent / 3) }
+    , ceq { ci = center, cj = vec3 -faceDimension -faceDimension faceDimension |> Vec3.add center, ni = vec3 -invSqrt3 -invSqrt3 invSqrt3, rj = vec3 (octoHalfExtent / 3) (octoHalfExtent / 3) (-octoHalfExtent / 3) }
+    , ceq { ci = center, cj = vec3 -faceDimension -faceDimension -faceDimension |> Vec3.add center, ni = vec3 -invSqrt3 -invSqrt3 -invSqrt3, rj = vec3 (octoHalfExtent / 3) (octoHalfExtent / 3) (octoHalfExtent / 3) }
 
     -- 3 face (near vertex) contacts
-    , ( vec3 (vertexDimension - delta) delta delta |> Vec3.add center
-      , ceq { ni = vec3 1 delta delta, rj = vec3 -octoHalfExtent 0 0 }
-      )
-    , ( vec3 delta delta (vertexDimension - delta) |> Vec3.add center
-      , ceq { ni = vec3 delta delta 1, rj = vec3 0 0 -octoHalfExtent }
-      )
-    , ( vec3 (delta - vertexDimension) delta delta |> Vec3.add center
-      , ceq { ni = vec3 -1 delta delta, rj = vec3 octoHalfExtent 0 0 }
-      )
+    , ceq { ci = center, cj = vec3 (vertexDimension - delta) delta delta |> Vec3.add center, ni = vec3 1 delta delta, rj = vec3 -octoHalfExtent 0 0 }
+    , ceq { ci = center, cj = vec3 delta delta (vertexDimension - delta) |> Vec3.add center, ni = vec3 delta delta 1, rj = vec3 0 0 -octoHalfExtent }
+    , ceq { ci = center, cj = vec3 (delta - vertexDimension) delta delta |> Vec3.add center, ni = vec3 -1 delta delta, rj = vec3 octoHalfExtent 0 0 }
 
     -- 3 face (near edge) contacts
-    , ( vec3 (edgeDimension - delta) (edgeDimension - delta) delta |> Vec3.add center
-      , ceq { ni = vec3 invSqrt2 invSqrt2 delta, rj = vec3 (delta - octoHalfExtent / 2) (-octoHalfExtent / 2) 0 }
-      )
-    , ( vec3 delta (edgeDimension - delta) (edgeDimension - delta) |> Vec3.add center
-      , ceq { ni = vec3 delta invSqrt2 invSqrt2, rj = vec3 0 (-octoHalfExtent / 2) (delta - octoHalfExtent / 2) }
-      )
-    , ( vec3 (delta - edgeDimension) -delta (delta - edgeDimension) |> Vec3.add center
-      , ceq { ni = vec3 -invSqrt2 -delta -invSqrt2, rj = vec3 (octoHalfExtent / 2) 0 (octoHalfExtent / 2) }
-      )
+    , ceq { ci = center, cj = vec3 (edgeDimension - delta) (edgeDimension - delta) delta |> Vec3.add center, ni = vec3 invSqrt2 invSqrt2 delta, rj = vec3 (delta - octoHalfExtent / 2) (-octoHalfExtent / 2) 0 }
+    , ceq { ci = center, cj = vec3 delta (edgeDimension - delta) (edgeDimension - delta) |> Vec3.add center, ni = vec3 delta invSqrt2 invSqrt2, rj = vec3 0 (-octoHalfExtent / 2) (delta - octoHalfExtent / 2) }
+    , ceq { ci = center, cj = vec3 (delta - edgeDimension) -delta (delta - edgeDimension) |> Vec3.add center, ni = vec3 -invSqrt2 -delta -invSqrt2, rj = vec3 (octoHalfExtent / 2) 0 (octoHalfExtent / 2) }
     ]
 
 
-completeSphereContactEquation : Float -> { ni : Vec3, rj : Vec3 } -> List (ContactEquation ())
-completeSphereContactEquation radius { ni, rj } =
-    [ { body1 = body1
-      , body2 = body2
-      , ni = ni
-      , ri = Vec3.scale radius ni
-      , rj = rj
-      , bounciness = 0
+completeSphereContactEquation : Float -> { ni : Vec3, rj : Vec3, ci : Vec3, cj : Vec3 } -> List Contact
+completeSphereContactEquation radius { ni, rj, ci, cj } =
+    [ { ni = ni
+      , pi = Vec3.add ci (Vec3.scale radius ni)
+      , pj = Vec3.add cj rj
       }
     ]

--- a/src/Internal/AABB.elm
+++ b/src/Internal/AABB.elm
@@ -8,7 +8,6 @@ module Internal.AABB exposing
     , toHalfExtends
     )
 
-import Array exposing (Array)
 import Internal.Const as Const
 import Internal.ConvexPolyhedron as ConvexPolyhedron exposing (ConvexPolyhedron)
 import Internal.Quaternion as Quaternion
@@ -102,10 +101,6 @@ toHalfExtends { lowerBound, upperBound } =
     lowerBound
         |> Vec3.sub upperBound
         |> Vec3.scale 0.5
-
-
-type T3
-    = T3 Float Float Float
 
 
 plane : Transform -> AABB

--- a/src/Internal/AABB.elm
+++ b/src/Internal/AABB.elm
@@ -1,11 +1,11 @@
 module Internal.AABB exposing
     ( AABB
     , convexPolyhedron
+    , dimesions
     , extend
     , impossible
     , plane
     , sphere
-    , toHalfExtends
     )
 
 import Internal.Const as Const
@@ -96,11 +96,9 @@ convexPolyhedron { vertices } transform =
         vertices
 
 
-toHalfExtends : AABB -> Vec3
-toHalfExtends { lowerBound, upperBound } =
-    lowerBound
-        |> Vec3.sub upperBound
-        |> Vec3.scale 0.5
+dimesions : AABB -> Vec3
+dimesions { lowerBound, upperBound } =
+    Vec3.sub upperBound lowerBound
 
 
 plane : Transform -> AABB

--- a/src/Internal/Body.elm
+++ b/src/Internal/Body.elm
@@ -232,7 +232,7 @@ raycast ray body =
                 Just raycastResult ->
                     case maybeClosestRaycastResult of
                         Just closestRaycastResult ->
-                            if raycastResult.distance < closestRaycastResult.distance then
+                            if raycastResult.distance - closestRaycastResult.distance < 0 then
                                 Just raycastResult
 
                             else

--- a/src/Internal/Body.elm
+++ b/src/Internal/Body.elm
@@ -146,18 +146,16 @@ updateMassProperties ({ mass } as body) =
                 1.0 / mass
 
         e =
-            body
-                |> computeAABB
-                |> AABB.toHalfExtends
+            AABB.dimesions (computeAABB body)
 
         ix =
-            1.0 / 12.0 * mass * (2 * e.y * 2 * e.y + 2 * e.z * 2 * e.z)
+            1.0 / 12.0 * mass * (e.y * e.y + e.z * e.z)
 
         iy =
-            1.0 / 12.0 * mass * (2 * e.x * 2 * e.x + 2 * e.z * 2 * e.z)
+            1.0 / 12.0 * mass * (e.x * e.x + e.z * e.z)
 
         iz =
-            1.0 / 12.0 * mass * (2 * e.y * 2 * e.y + 2 * e.x * 2 * e.x)
+            1.0 / 12.0 * mass * (e.y * e.y + e.x * e.x)
 
         inertia =
             vec3 ix iy iz

--- a/src/Internal/Body.elm
+++ b/src/Internal/Body.elm
@@ -1,6 +1,5 @@
 module Internal.Body exposing
     ( Body
-    , BodyId
     , Protected(..)
     , addGravity
     , compound
@@ -20,16 +19,12 @@ import Internal.Transform as Transform exposing (Transform)
 import Internal.Vector3 as Vec3 exposing (Vec3, vec3)
 
 
-type alias BodyId =
-    Int
-
-
 type Protected data
     = Protected (Body data)
 
 
 type alias Body data =
-    { id : BodyId
+    { id : Int
     , data : data
     , material : Material
     , position : Vec3

--- a/src/Internal/ConvexPolyhedron.elm
+++ b/src/Internal/ConvexPolyhedron.elm
@@ -645,8 +645,11 @@ projectHelp localAxis maxVal minVal currentVertices =
 
         vec :: remainingVertices ->
             let
+                {- val =
+                   Vec3.dot vec localAxis
+                -}
                 val =
-                    Vec3.dot vec localAxis
+                    vec.x * localAxis.x + vec.y * localAxis.y + vec.z * localAxis.z
             in
             projectHelp
                 localAxis

--- a/src/Internal/ConvexPolyhedron.elm
+++ b/src/Internal/ConvexPolyhedron.elm
@@ -546,7 +546,7 @@ testFaceNormals t1 hull1 t2 hull2 quat faces bestSoFar =
                         hull2
                         quat
                         restFaces
-                        (if d < bestSoFar.dmin then
+                        (if d - bestSoFar.dmin < 0 then
                             { dmin = d, target = rotatedNormal }
 
                          else
@@ -579,7 +579,7 @@ testEdges t1 hull1 t2 hull2 bestSoFar =
                             Just { dmin } ->
                                 case testSepAxis t1 hull1 t2 hull2 (Vec3.normalize cross) of
                                     Just dist ->
-                                        if dist < dmin then
+                                        if dist - dmin < 0 then
                                             Just
                                                 { dmin = dist
                                                 , target = Vec3.normalize cross
@@ -610,7 +610,7 @@ testSepAxis t1 hull1 t2 hull2 axis =
         ( max2, min2 ) =
             project t2 hull2 axis
     in
-    if max1 < min2 || max2 < min1 then
+    if max1 - min2 < 0 || max2 - min1 < 0 then
         Nothing
 
     else
@@ -794,7 +794,7 @@ sphereTestFace radius normal vertices acc =
                     -- a negative value prevents a face or edge contact match
                     -1
     in
-    if faceDistance < radius && faceDistance > 0.0 then
+    if faceDistance - radius < 0 && faceDistance > 0.0 then
         -- Sphere intersects the face plane.
         -- Assume 3 or more valid vertices to proceed
         -- Check if the sphere center projects onto the face plane INSIDE the face polygon.
@@ -859,7 +859,7 @@ sphereTestEdge prevVertex vertex (( _, minDistanceSq ) as statusQuo) =
                 vertexLengthSq =
                     Vec3.lengthSquared candidate
             in
-            if vertexLengthSq < minDistanceSq then
+            if vertexLengthSq - minDistanceSq < 0 then
                 ( Just candidate, vertexLengthSq )
 
             else
@@ -887,7 +887,7 @@ sphereTestEdge prevVertex vertex (( _, minDistanceSq ) as statusQuo) =
         -- no contact.
         PossibleVertexContact (betterVertexContact prevVertex)
 
-    else if offset * offset > Vec3.lengthSquared edge then
+    else if offset * offset - Vec3.lengthSquared edge > 0 then
         -- vertex is closest in this edge,
         -- but there may be a closer edge or
         -- no contact.
@@ -901,7 +901,7 @@ sphereTestEdge prevVertex vertex (( _, minDistanceSq ) as statusQuo) =
             edgeDistanceSq =
                 Vec3.lengthSquared edgeContact
         in
-        if edgeDistanceSq < minDistanceSq then
+        if edgeDistanceSq - minDistanceSq < 0 then
             EdgeContact ( edgeContact, edgeDistanceSq )
 
         else
@@ -1033,7 +1033,7 @@ raycast { direction, from } transform convex =
                     if isInsidePolygon then
                         case maybeHit of
                             Just { distance } ->
-                                if scalar < distance then
+                                if scalar - distance < 0 then
                                     Just
                                         { distance = scalar
                                         , point = intersectionPoint

--- a/src/Internal/ConvexPolyhedron.elm
+++ b/src/Internal/ConvexPolyhedron.elm
@@ -630,18 +630,47 @@ project transform { vertices } axis =
             Vec3.zero
                 |> Transform.pointToLocalFrame transform
                 |> Vec3.dot localAxis
+
+        ( maxVal, minVal ) =
+            projectHelp localAxis -Const.maxNumber Const.maxNumber vertices
     in
-    List.foldl
-        (\vec ( maxVal, minVal ) ->
+    ( maxVal - add, minVal - add )
+
+
+projectHelp : Vec3 -> Float -> Float -> List Vec3 -> ( Float, Float )
+projectHelp localAxis maxVal minVal currentVertices =
+    case currentVertices of
+        [] ->
+            ( maxVal, minVal )
+
+        vec :: remainingVertices ->
             let
                 val =
                     Vec3.dot vec localAxis
             in
-            ( max maxVal val, min minVal val )
-        )
-        ( -Const.maxNumber, Const.maxNumber )
-        vertices
-        |> (\( maxVal, minVal ) -> ( maxVal - add, minVal - add ))
+            projectHelp
+                localAxis
+                (max maxVal val)
+                (min minVal val)
+                remainingVertices
+
+
+max : Float -> Float -> Float
+max a b =
+    if a - b > 0 then
+        a
+
+    else
+        b
+
+
+min : Float -> Float -> Float
+min a b =
+    if b - a > 0 then
+        a
+
+    else
+        b
 
 
 {-| Encapsulated result of sphereTestFace

--- a/src/Internal/Equation.elm
+++ b/src/Internal/Equation.elm
@@ -1,7 +1,6 @@
-module Internal.SolverEquation exposing
-    ( ContactEquation
-    , SolverEquation
-    , addSolverEquations
+module Internal.Equation exposing
+    ( Equation
+    , addEquations
     , computeGWlambda
     )
 
@@ -34,7 +33,7 @@ type EquationKind
     | Friction FrictionEquation
 
 
-type alias SolverEquation =
+type alias Equation =
     { kind : EquationKind
     , bodyId1 : BodyId
     , bodyId2 : BodyId
@@ -50,8 +49,8 @@ type alias SolverEquation =
     }
 
 
-addSolverEquations : Float -> Vec3 -> Body data -> Body data -> Contact -> List SolverEquation -> List SolverEquation
-addSolverEquations dt gravity body1 body2 contact =
+addEquations : Float -> Vec3 -> Body data -> Body data -> Contact -> List Equation -> List Equation
+addEquations dt gravity body1 body2 contact =
     let
         μg =
             Material.contactFriction
@@ -186,7 +185,7 @@ defaultStiffness =
     10000000
 
 
-initSolverParams : Float -> Body data -> Body data -> SolverEquation -> SolverEquation
+initSolverParams : Float -> Body data -> Body data -> Equation -> Equation
 initSolverParams dt bi bj solverEquation =
     { kind = solverEquation.kind
     , bodyId1 = solverEquation.bodyId1
@@ -205,7 +204,7 @@ initSolverParams dt bi bj solverEquation =
 
 {-| Computes the RHS of the SPOOK equation
 -}
-computeB : Float -> Body data -> Body data -> SolverEquation -> Float
+computeB : Float -> Body data -> Body data -> Equation -> Float
 computeB dt bi bj solverEquation =
     case solverEquation.kind of
         Contact contactEquation ->
@@ -215,7 +214,7 @@ computeB dt bi bj solverEquation =
             computeFrictionB dt bi bj solverEquation frictionEquation
 
 
-computeContactB : Float -> Body data -> Body data -> SolverEquation -> ContactEquation -> Float
+computeContactB : Float -> Body data -> Body data -> Equation -> ContactEquation -> Float
 computeContactB dt bi bj ({ spookA, spookB } as solverEquation) { bounciness, ri, rj, ni } =
     let
         g =
@@ -237,7 +236,7 @@ computeContactB dt bi bj ({ spookA, spookB } as solverEquation) { bounciness, ri
     -g * spookA - gW * spookB - dt * giMf
 
 
-computeFrictionB : Float -> Body data -> Body data -> SolverEquation -> FrictionEquation -> Float
+computeFrictionB : Float -> Body data -> Body data -> Equation -> FrictionEquation -> Float
 computeFrictionB dt bi bj ({ spookB } as solverEquation) _ =
     let
         gW =
@@ -255,7 +254,7 @@ computeFrictionB dt bi bj ({ spookB } as solverEquation) _ =
   - f are the forces on the bodies
 
 -}
-computeGiMf : Body data -> Body data -> SolverEquation -> Float
+computeGiMf : Body data -> Body data -> Equation -> Float
 computeGiMf bi bj { jacobianElementA, jacobianElementB } =
     (+)
         (JacobianElement.mulVec
@@ -272,7 +271,7 @@ computeGiMf bi bj { jacobianElementA, jacobianElementB } =
 
 {-| Compute G\_inv(M)\_G' + eps, the denominator part of the SPOOK equation:
 -}
-computeC : Body data -> Body data -> SolverEquation -> Float
+computeC : Body data -> Body data -> Equation -> Float
 computeC bi bj { jacobianElementA, jacobianElementB, spookEps } =
     bi.invMass
         + bj.invMass
@@ -283,7 +282,7 @@ computeC bi bj { jacobianElementA, jacobianElementB, spookEps } =
 
 {-| Computes G\*Wlambda, where W are the body velocities
 -}
-computeGWlambda : SolverBody data -> SolverBody data -> SolverEquation -> Float
+computeGWlambda : SolverBody data -> SolverBody data -> Equation -> Float
 computeGWlambda bi bj { jacobianElementA, jacobianElementB } =
     JacobianElement.mulVec bi.vlambda bi.wlambda jacobianElementA
         + JacobianElement.mulVec bj.vlambda bj.wlambda jacobianElementB
@@ -291,7 +290,7 @@ computeGWlambda bi bj { jacobianElementA, jacobianElementB } =
 
 {-| Computes G\*W, where W are the body velocities
 -}
-computeGW : Body data -> Body data -> SolverEquation -> Float
+computeGW : Body data -> Body data -> Equation -> Float
 computeGW bi bj { jacobianElementA, jacobianElementB } =
     JacobianElement.mulVec bi.velocity bi.angularVelocity jacobianElementA
         + JacobianElement.mulVec bj.velocity bj.angularVelocity jacobianElementB

--- a/src/Internal/Equation.elm
+++ b/src/Internal/Equation.elm
@@ -8,7 +8,7 @@ import Internal.Body exposing (Body, BodyId)
 import Internal.JacobianElement as JacobianElement exposing (JacobianElement)
 import Internal.Material as Material
 import Internal.Matrix3 as Mat3 exposing (Mat3)
-import Internal.NarrowPhase exposing (Contact, ContactGroup)
+import Internal.NarrowPhase exposing (Contact)
 import Internal.SolverBody as SolverBody exposing (SolverBody)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 

--- a/src/Internal/Equation.elm
+++ b/src/Internal/Equation.elm
@@ -4,7 +4,7 @@ module Internal.Equation exposing
     , computeGWlambda
     )
 
-import Internal.Body exposing (Body, BodyId)
+import Internal.Body exposing (Body)
 import Internal.JacobianElement as JacobianElement exposing (JacobianElement)
 import Internal.Material as Material
 import Internal.Matrix3 as Mat3 exposing (Mat3)
@@ -35,8 +35,8 @@ type EquationKind
 
 type alias Equation =
     { kind : EquationKind
-    , bodyId1 : BodyId
-    , bodyId2 : BodyId
+    , bodyId1 : Int
+    , bodyId2 : Int
     , minForce : Float
     , maxForce : Float
     , solverBs : Float

--- a/src/Internal/Equation.elm
+++ b/src/Internal/Equation.elm
@@ -284,8 +284,14 @@ computeC bi bj { jacobianElementA, jacobianElementB, spookEps } =
 -}
 computeGWlambda : SolverBody data -> SolverBody data -> Equation -> Float
 computeGWlambda bi bj { jacobianElementA, jacobianElementB } =
-    JacobianElement.mulVec bi.vlambda bi.wlambda jacobianElementA
-        + JacobianElement.mulVec bj.vlambda bj.wlambda jacobianElementB
+    {-
+       JacobianElement.mulVec bi.vlambda bi.wlambda jacobianElementA
+           + JacobianElement.mulVec bj.vlambda bj.wlambda jacobianElementB
+    -}
+    (jacobianElementA.spatial.x * bi.vlambda.x + jacobianElementA.spatial.y * bi.vlambda.y + jacobianElementA.spatial.z * bi.vlambda.z)
+        + (jacobianElementA.rotational.x * bi.wlambda.x + jacobianElementA.rotational.y * bi.wlambda.y + jacobianElementA.rotational.z * bi.wlambda.z)
+        + (jacobianElementB.spatial.x * bj.vlambda.x + jacobianElementB.spatial.y * bj.vlambda.y + jacobianElementB.spatial.z * bj.vlambda.z)
+        + (jacobianElementB.rotational.x * bj.wlambda.x + jacobianElementB.rotational.y * bj.wlambda.y + jacobianElementB.rotational.z * bj.wlambda.z)
 
 
 {-| Computes G\*W, where W are the body velocities

--- a/src/Internal/NarrowPhase.elm
+++ b/src/Internal/NarrowPhase.elm
@@ -6,7 +6,7 @@ module Internal.NarrowPhase exposing
     , getContacts
     )
 
-import Internal.Body as Body exposing (Body, BodyId)
+import Internal.Body as Body exposing (Body)
 import Internal.Const as Const
 import Internal.ConvexPolyhedron as ConvexPolyhedron exposing (ConvexPolyhedron)
 import Internal.Material as Material

--- a/src/Internal/NarrowPhase.elm
+++ b/src/Internal/NarrowPhase.elm
@@ -1,143 +1,169 @@
 module Internal.NarrowPhase exposing
-    ( addSphereConvexContacts
+    ( Contact
+    , ContactGroup
+    , Order(..)
+    , addSphereConvexContacts
     , getContacts
     )
 
-import Array exposing (Array)
 import Internal.Body as Body exposing (Body, BodyId)
 import Internal.Const as Const
 import Internal.ConvexPolyhedron as ConvexPolyhedron exposing (ConvexPolyhedron)
 import Internal.Material as Material
 import Internal.Quaternion as Quaternion
 import Internal.Shape as Shape exposing (Kind(..), Shape)
-import Internal.SolverEquation exposing (ContactEquation)
 import Internal.Transform as Transform exposing (Transform)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Internal.World as World exposing (World)
 
 
-getContacts : World data -> List (ContactEquation data)
+type alias Contact =
+    { ni : Vec3 -- contact normal, pointing out of body1
+    , pi : Vec3 -- contact point on body1
+    , pj : Vec3 -- contact point on body2
+    }
+
+
+type alias ContactGroup data =
+    { body1 : Body data
+    , body2 : Body data
+    , contacts : List Contact
+    }
+
+
+getContacts : World data -> List (ContactGroup data)
 getContacts world =
     List.foldl
-        (\( body1, body2 ) -> getBodyContacts world body1 body2)
+        (\( body1, body2 ) ->
+            (::)
+                { body1 = body1
+                , body2 = body2
+                , contacts = getBodyContacts body1 body2
+                }
+        )
         []
         (World.getPairs world)
 
 
-getBodyContacts : World data -> Body data -> Body data -> List (ContactEquation data) -> List (ContactEquation data)
-getBodyContacts world body1 body2 contactEquations =
+getBodyContacts : Body data -> Body data -> List Contact
+getBodyContacts body1 body2 =
     List.foldl
         (\shape1 currentContactEquations1 ->
             List.foldl
-                (\shape2 currentContactEquations2 ->
-                    getShapeContacts
+                (\shape2 ->
+                    addShapeContacts
                         (Body.shapeWorldTransform shape1 body1)
                         shape1
-                        body1
                         (Body.shapeWorldTransform shape2 body2)
                         shape2
-                        body2
-                        currentContactEquations2
                 )
                 currentContactEquations1
                 body2.shapes
         )
-        contactEquations
+        []
         body1.shapes
 
 
-getShapeContacts : Transform -> Shape -> Body data -> Transform -> Shape -> Body data -> List (ContactEquation data) -> List (ContactEquation data)
-getShapeContacts shapeTransform1 shape1 body1 shapeTransform2 shape2 body2 contactEquations =
+type Order
+    = ASC
+    | DESC
+
+
+orderContact : Order -> Contact -> Contact
+orderContact order contact =
+    case order of
+        ASC ->
+            contact
+
+        DESC ->
+            { ni = Vec3.negate contact.ni
+            , pi = contact.pj
+            , pj = contact.pi
+            }
+
+
+addShapeContacts : Transform -> Shape -> Transform -> Shape -> List Contact -> List Contact
+addShapeContacts shapeTransform1 shape1 shapeTransform2 shape2 contacts =
     case ( shape1.kind, shape2.kind ) of
         ( Plane, Plane ) ->
             -- don't collide two planes
-            contactEquations
+            contacts
 
         ( Plane, Convex convexPolyhedron ) ->
             addPlaneConvexContacts
+                ASC
                 shapeTransform1
-                body1
                 shapeTransform2
                 convexPolyhedron
-                body2
-                contactEquations
+                contacts
 
         ( Plane, Sphere radius ) ->
             addPlaneSphereContacts
+                ASC
                 shapeTransform1
-                body1
                 shapeTransform2
                 radius
-                body2
-                contactEquations
+                contacts
 
         ( Convex convexPolyhedron, Plane ) ->
             addPlaneConvexContacts
+                DESC
                 shapeTransform2
-                body2
                 shapeTransform1
                 convexPolyhedron
-                body1
-                contactEquations
+                contacts
 
         ( Convex convexPolyhedron1, Convex convexPolyhedron2 ) ->
             addConvexConvexContacts
                 shapeTransform1
                 convexPolyhedron1
-                body1
                 shapeTransform2
                 convexPolyhedron2
-                body2
-                contactEquations
+                contacts
 
         ( Convex convexPolyhedron, Sphere radius ) ->
             addSphereConvexContacts
+                DESC
                 shapeTransform2
                 radius
-                body2
                 shapeTransform1
                 convexPolyhedron
-                body1
-                contactEquations
+                contacts
 
         ( Sphere radius, Plane ) ->
             addPlaneSphereContacts
+                DESC
                 shapeTransform2
-                body2
                 shapeTransform1
                 radius
-                body1
-                contactEquations
+                contacts
 
         ( Sphere radius, Convex convexPolyhedron ) ->
             addSphereConvexContacts
+                ASC
                 shapeTransform1
                 radius
-                body1
                 shapeTransform2
                 convexPolyhedron
-                body2
-                contactEquations
+                contacts
 
         ( Sphere radius1, Sphere radius2 ) ->
             addSphereSphereContacts
                 shapeTransform1
                 radius1
-                body1
                 shapeTransform2
                 radius2
-                body2
-                contactEquations
+                contacts
 
 
-addPlaneConvexContacts : Transform -> Body data -> Transform -> ConvexPolyhedron -> Body data -> List (ContactEquation data) -> List (ContactEquation data)
-addPlaneConvexContacts planeTransform planeBody convexTransform convexPolyhedron convexBody contactEquations =
+addPlaneConvexContacts : Order -> Transform -> Transform -> ConvexPolyhedron -> List Contact -> List Contact
+addPlaneConvexContacts order planeTransform convexTransform convexPolyhedron contacts =
     let
         worldNormal =
             Quaternion.rotate planeTransform.orientation Vec3.k
     in
     List.foldl
-        (\vertex currentContactEquations ->
+        (\vertex currentContacts ->
             let
                 worldVertex =
                     Transform.pointToWorldFrame convexTransform vertex
@@ -148,66 +174,44 @@ addPlaneConvexContacts planeTransform planeBody convexTransform convexPolyhedron
                         |> Vec3.dot worldNormal
             in
             if dot <= 0 then
-                { body1 = planeBody
-                , body2 = convexBody
-                , ni = worldNormal
-                , ri =
-                    Vec3.sub
-                        (worldNormal
+                orderContact order
+                    { ni = worldNormal
+                    , pi =
+                        worldNormal
                             |> Vec3.scale dot
                             |> Vec3.sub worldVertex
-                        )
-                        planeBody.position
-                , rj = Vec3.sub worldVertex convexBody.position
-                , bounciness = Material.contactBounciness planeBody.material convexBody.material
-                }
-                    :: currentContactEquations
+                    , pj = worldVertex
+                    }
+                    :: currentContacts
 
             else
-                currentContactEquations
+                currentContacts
         )
-        contactEquations
+        contacts
         convexPolyhedron.vertices
 
 
-addConvexConvexContacts : Transform -> ConvexPolyhedron -> Body data -> Transform -> ConvexPolyhedron -> Body data -> List (ContactEquation data) -> List (ContactEquation data)
-addConvexConvexContacts shapeTransform1 convexPolyhedron1 body1 shapeTransform2 convexPolyhedron2 body2 contactEquations =
+addConvexConvexContacts : Transform -> ConvexPolyhedron -> Transform -> ConvexPolyhedron -> List Contact -> List Contact
+addConvexConvexContacts shapeTransform1 convexPolyhedron1 shapeTransform2 convexPolyhedron2 contacts =
     case ConvexPolyhedron.findSeparatingAxis shapeTransform1 convexPolyhedron1 shapeTransform2 convexPolyhedron2 of
         Just sepAxis ->
             ConvexPolyhedron.clipAgainstHull shapeTransform1 convexPolyhedron1 shapeTransform2 convexPolyhedron2 sepAxis -100 100
                 |> List.foldl
-                    (\{ point, normal, depth } currentContactEquations ->
-                        let
-                            q =
-                                normal
-                                    |> Vec3.negate
-                                    |> Vec3.scale depth
-
-                            ri =
-                                Vec3.add point q
-                                    |> Vec3.add (Vec3.negate body1.position)
-
-                            rj =
-                                point
-                                    |> Vec3.add (Vec3.negate body2.position)
-                        in
-                        { body1 = body1
-                        , body2 = body2
-                        , ni = Vec3.negate sepAxis
-                        , ri = ri
-                        , rj = rj
-                        , bounciness = Material.contactBounciness body1.material body2.material
+                    (\{ point, normal, depth } currentContacts ->
+                        { ni = Vec3.negate sepAxis
+                        , pi = Vec3.sub point (Vec3.scale depth normal)
+                        , pj = point
                         }
-                            :: currentContactEquations
+                            :: currentContacts
                     )
-                    contactEquations
+                    contacts
 
         Nothing ->
-            contactEquations
+            contacts
 
 
-addPlaneSphereContacts : Transform -> Body data -> Transform -> Float -> Body data -> List (ContactEquation data) -> List (ContactEquation data)
-addPlaneSphereContacts planeTransform body1 t2 radius body2 contactEquations =
+addPlaneSphereContacts : Order -> Transform -> Transform -> Float -> List Contact -> List Contact
+addPlaneSphereContacts order planeTransform t2 radius contacts =
     let
         worldPlaneNormal =
             Quaternion.rotate planeTransform.orientation Vec3.k
@@ -223,27 +227,19 @@ addPlaneSphereContacts planeTransform body1 t2 radius body2 contactEquations =
                 |> Vec3.dot worldPlaneNormal
     in
     if dot <= 0 then
-        { body1 = body1
-        , body2 = body2
-        , ni = worldPlaneNormal
-        , ri =
-            Vec3.sub
-                (worldPlaneNormal
-                    |> Vec3.scale dot
-                    |> Vec3.sub worldVertex
-                )
-                body1.position
-        , rj = Vec3.sub worldVertex body2.position
-        , bounciness = Material.contactBounciness body1.material body2.material
-        }
-            :: contactEquations
+        orderContact order
+            { ni = worldPlaneNormal
+            , pi = Vec3.sub worldVertex (Vec3.scale dot worldPlaneNormal)
+            , pj = worldVertex
+            }
+            :: contacts
 
     else
-        contactEquations
+        contacts
 
 
-addSphereConvexContacts : Transform -> Float -> Body data -> Transform -> ConvexPolyhedron -> Body data -> List (ContactEquation data) -> List (ContactEquation data)
-addSphereConvexContacts { position } radius body1 t2 hull2 body2 contactEquations =
+addSphereConvexContacts : Order -> Transform -> Float -> Transform -> ConvexPolyhedron -> List Contact -> List Contact
+addSphereConvexContacts order { position } radius t2 hull2 contacts =
     let
         ( maybeWorldContact, penetration ) =
             ConvexPolyhedron.sphereContact position radius t2 hull2
@@ -254,21 +250,19 @@ addSphereConvexContacts { position } radius body1 t2 hull2 body2 contactEquation
                 worldNormal =
                     Vec3.direction worldContact2 position
             in
-            { body1 = body1
-            , body2 = body2
-            , ni = worldNormal
-            , ri = Vec3.scale radius worldNormal
-            , rj = Vec3.sub worldContact2 t2.position
-            , bounciness = Material.contactBounciness body1.material body2.material
-            }
-                :: contactEquations
+            orderContact order
+                { ni = worldNormal
+                , pi = Vec3.add worldContact2 (Vec3.scale penetration worldNormal)
+                , pj = worldContact2
+                }
+                :: contacts
 
         Nothing ->
-            contactEquations
+            contacts
 
 
-addSphereSphereContacts : Transform -> Float -> Body data -> Transform -> Float -> Body data -> List (ContactEquation data) -> List (ContactEquation data)
-addSphereSphereContacts t1 radius1 body1 t2 radius2 body2 contactEquations =
+addSphereSphereContacts : Transform -> Float -> Transform -> Float -> List Contact -> List Contact
+addSphereSphereContacts t1 radius1 t2 radius2 contacts =
     let
         center1 =
             Transform.pointToWorldFrame t1 Vec3.zero
@@ -285,14 +279,11 @@ addSphereSphereContacts t1 radius1 body1 t2 radius2 body2 contactEquations =
             Vec3.direction center2 center1
     in
     if distance > 0 then
-        contactEquations
+        contacts
 
     else
-        { body1 = body1
-        , body2 = body2
-        , ni = normal
-        , ri = Vec3.scale radius1 normal
-        , rj = Vec3.scale -radius2 normal
-        , bounciness = Material.contactBounciness body1.material body2.material
+        { ni = normal
+        , pi = Vec3.add center1 (Vec3.scale (radius1 - distance) normal)
+        , pj = Vec3.add center2 (Vec3.scale -radius2 normal)
         }
-            :: contactEquations
+            :: contacts

--- a/src/Internal/Solver.elm
+++ b/src/Internal/Solver.elm
@@ -29,7 +29,7 @@ solve dt contactEquations world =
 
 solveHelp : Int -> SolveContext data -> SolveContext data
 solveHelp number context =
-    if number == 0 || context.deltalambdaTot < Const.precision then
+    if number == 0 || context.deltalambdaTot - Const.precision < 0 then
         context
 
     else
@@ -98,10 +98,10 @@ solveEquationsGroup body1 body2 solverEquations deltalambdaTot currentSolverEqua
                     solverEquation.solverInvCs * (solverEquation.solverBs - gWlambda - solverEquation.spookEps * equationSolverLambda)
 
                 deltalambda =
-                    if equationSolverLambda + deltalambdaPrev < solverEquation.minForce then
+                    if equationSolverLambda + deltalambdaPrev - solverEquation.minForce < 0 then
                         solverEquation.minForce - equationSolverLambda
 
-                    else if equationSolverLambda + deltalambdaPrev > solverEquation.maxForce then
+                    else if equationSolverLambda + deltalambdaPrev - solverEquation.maxForce > 0 then
                         solverEquation.maxForce - equationSolverLambda
 
                     else

--- a/src/Internal/Solver.elm
+++ b/src/Internal/Solver.elm
@@ -169,47 +169,6 @@ solveEquationsGroup body1 body2 solverEquations deltalambdaTot currentEquations 
                 remainingEquations
 
 
-solveStep : SolveContext data -> SolveContext data
-solveStep context =
-    List.foldl
-        (\{ bodyId1, bodyId2, solverEquations } newContext ->
-            case Array.get bodyId1 newContext.bodies of
-                Just (Just body1) ->
-                    case Array.get bodyId2 newContext.bodies of
-                        Just (Just body2) ->
-                            let
-                                groupContext =
-                                    solveEquationsGroup
-                                        body1
-                                        body2
-                                        []
-                                        newContext.deltalambdaTot
-                                        solverEquations
-                            in
-                            { world = newContext.world
-                            , deltalambdaTot = groupContext.deltalambdaTot
-                            , equationsGroups =
-                                { bodyId1 = bodyId1
-                                , bodyId2 = bodyId2
-                                , solverEquations = groupContext.solverEquations
-                                }
-                                    :: newContext.equationsGroups
-                            , bodies =
-                                newContext.bodies
-                                    |> Array.set bodyId1 (Just groupContext.body1)
-                                    |> Array.set bodyId2 (Just groupContext.body2)
-                            }
-
-                        _ ->
-                            newContext
-
-                _ ->
-                    newContext
-        )
-        { context | equationsGroups = [], deltalambdaTot = 0 }
-        context.equationsGroups
-
-
 type alias SolveContext data =
     { bodies : Array (Maybe (SolverBody data))
     , equationsGroups : List EquationsGroup

--- a/src/Internal/Solver.elm
+++ b/src/Internal/Solver.elm
@@ -1,7 +1,7 @@
 module Internal.Solver exposing (solve)
 
 import Array exposing (Array)
-import Internal.Body as Body exposing (Body, BodyId)
+import Internal.Body as Body exposing (Body)
 import Internal.Const as Const
 import Internal.Equation as Equation exposing (Equation, addEquations)
 import Internal.NarrowPhase exposing (Contact, ContactGroup)
@@ -181,8 +181,8 @@ type alias SolveContext data =
 
 
 type alias EquationsGroup =
-    { bodyId1 : BodyId
-    , bodyId2 : BodyId
+    { bodyId1 : Int
+    , bodyId2 : Int
     , solverEquations : List ( Float, Equation )
     }
 

--- a/src/Internal/Solver.elm
+++ b/src/Internal/Solver.elm
@@ -25,8 +25,11 @@ solve dt contactGroups world =
                 world.bodies
 
         equationsGroups =
-            List.map
-                (solverEquationsGroup dt world.gravity)
+            List.foldl
+                (\contactGroup ->
+                    (::) (solverEquationsGroup dt world.gravity contactGroup)
+                )
+                []
                 contactGroups
 
         solvedBodies =

--- a/src/Internal/Vector3.elm
+++ b/src/Internal/Vector3.elm
@@ -4,8 +4,7 @@ module Internal.Vector3 exposing
     , length, lengthSquared, distance, distanceSquared, tangents, lerp
     )
 
-{-| A high performance linear algebra library using native JS arrays. Geared
-towards 3D graphics and use with `Graphics.WebGL`. All vectors are immutable.
+{-|
 
 
 # Create

--- a/src/Internal/World.elm
+++ b/src/Internal/World.elm
@@ -66,7 +66,8 @@ getPairsHelp list result =
 bodiesMayOverlap : Body data -> Body data -> Bool
 bodiesMayOverlap body1 body2 =
     (body1.boundingSphereRadius + body2.boundingSphereRadius)
-        > Vec3.distance body1.position body2.position
+        - Vec3.distance body1.position body2.position
+        > 0
 
 
 raycast :
@@ -80,7 +81,7 @@ raycast ray { bodies } =
                 Just raycastResult ->
                     case maybeClosestRaycastResult of
                         Just closestRaycastResult ->
-                            if raycastResult.distance < closestRaycastResult.distance then
+                            if raycastResult.distance - closestRaycastResult.distance < 0 then
                                 Just
                                     { body = body
                                     , distance = raycastResult.distance

--- a/src/Internal/World.elm
+++ b/src/Internal/World.elm
@@ -7,7 +7,7 @@ module Internal.World exposing
     , tick
     )
 
-import Internal.Body as Body exposing (Body, BodyId)
+import Internal.Body as Body exposing (Body)
 import Internal.Vector3 as Vec3 exposing (Vec3, vec3)
 
 
@@ -17,8 +17,8 @@ type Protected data
 
 type alias World data =
     { bodies : List (Body data)
-    , freeIds : List BodyId
-    , nextBodyId : BodyId
+    , freeIds : List Int
+    , nextBodyId : Int
     , gravity : Vec3
     }
 

--- a/src/Physics/Debug.elm
+++ b/src/Physics/Debug.elm
@@ -30,8 +30,11 @@ import Physics.World exposing (World)
 getContacts : World data -> List { x : Float, y : Float, z : Float }
 getContacts (Protected world) =
     List.foldl
-        (\{ body1, body2, ri, rj } acc ->
-            Vec3.add body1.position ri :: Vec3.add body2.position rj :: acc
+        (\{ contacts } acc1 ->
+            List.foldl
+                (\{ pi, pj } acc2 -> pi :: pj :: acc2)
+                acc1
+                contacts
         )
         []
         -- TODO: maybe cache the previous contacts in the world

--- a/tests/ConvexPolyhedronTest.elm
+++ b/tests/ConvexPolyhedronTest.elm
@@ -590,7 +590,8 @@ normalizeVec3Towards approximation canonical =
             || ((Vec3.sub approximation canonical
                     |> Vec3.lengthSquared
                 )
-                    < Const.precision
+                    - Const.precision
+                    < 0
                )
     then
         canonical

--- a/tests/NarrowPhaseTest.elm
+++ b/tests/NarrowPhaseTest.elm
@@ -2,12 +2,11 @@ module NarrowPhaseTest exposing (addSphereConvexContacts)
 
 import Expect exposing (Expectation)
 import Fixtures.ConvexPolyhedron as HullFixtures
-import Fixtures.NarrowPhase exposing (body1, body2)
+import Fixtures.NarrowPhase
 import Internal.Body as Body exposing (Body)
 import Internal.Const as Const
-import Internal.NarrowPhase as NarrowPhase
+import Internal.NarrowPhase as NarrowPhase exposing (Contact, Order(..))
 import Internal.Quaternion as Quaternion
-import Internal.SolverEquation exposing (ContactEquation)
 import Internal.Vector3 as Vec3 exposing (Vec3, vec3)
 import Test exposing (..)
 
@@ -68,16 +67,15 @@ addSphereConvexContacts =
                     |> List.map
                         (\position ->
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 boxHull
-                                body2
                                 []
                         )
                     |> expectNormalizedEqual
@@ -92,16 +90,15 @@ addSphereConvexContacts =
                     |> List.concatMap
                         (\position ->
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 boxHull
-                                body2
                                 []
                         )
                     |> Expect.equal []
@@ -111,16 +108,15 @@ addSphereConvexContacts =
                     |> List.map
                         (\position ->
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 octoHull
-                                body2
                                 []
                         )
                     |> expectNormalizedEqual
@@ -135,16 +131,15 @@ addSphereConvexContacts =
                     |> List.concatMap
                         (\position ->
                             NarrowPhase.addSphereConvexContacts
+                                ASC
                                 { position = center
                                 , orientation = Quaternion.identity
                                 }
                                 radius
-                                body1
                                 { position = position
                                 , orientation = Quaternion.identity
                                 }
                                 octoHull
-                                body2
                                 []
                         )
                     |> Expect.equal []
@@ -177,23 +172,22 @@ normalizeListTowards normalizeElementTowards expected actual =
         actual
 
 
-normalizeContactTowards : ContactEquation () -> ContactEquation () -> ContactEquation ()
+normalizeContactTowards : Contact -> Contact -> Contact
 normalizeContactTowards expected actual =
     -- optimize common case
     if actual == expected then
         actual
 
     else
-        { actual
-            | ni = normalizeVec3Towards expected.ni actual.ni
-            , ri = normalizeVec3Towards expected.ri actual.ri
-            , rj = normalizeVec3Towards expected.rj actual.rj
+        { ni = normalizeVec3Towards expected.ni actual.ni
+        , pi = normalizeVec3Towards expected.pi actual.pi
+        , pj = normalizeVec3Towards expected.pj actual.pj
         }
 
 
 normalizeVec3Towards : Vec3 -> Vec3 -> Vec3
 normalizeVec3Towards expected actual =
-    if Vec3.distanceSquared expected actual < Const.precision then
+    if Vec3.distanceSquared expected actual - Const.precision < 0 then
         -- ignore any negligible difference.
         expected
 


### PR DESCRIPTION
* Reworked the narrow phase and the solver to solve bodies in groups — this means less expensive `Array.set` calls
* Inlined expensive computations on the hot paths
* Replaced some fold with recursions to reduce memory allocations
* Speedup comparisons, the compiled version of `a - b > 0` is faster than `a > b`