### PR TITLE
Finalize API

### DIFF
--- a/benchmarks/ConvexConvex.elm
+++ b/benchmarks/ConvexConvex.elm
@@ -42,7 +42,7 @@ colliding =
             Frame3d.atPoint Point3d.origin
                 |> Frame3d.rotateAround Axis3d.y (Angle.radians (pi / 4))
                 |> Frame3d.rotateAround Axis3d.x (Angle.radians (pi / 20))
-                |> Frame3d.moveTo (Point3d.fromMeters { x = 0, y = 0, z = 0.9 })
+                |> Frame3d.moveTo (Point3d.meters 0 0 0.9)
 
         originFrame3d =
             Frame3d.atPoint Point3d.origin
@@ -78,7 +78,7 @@ separated =
             Frame3d.atPoint Point3d.origin
                 |> Frame3d.rotateAround Axis3d.y (Angle.radians (pi / 4))
                 |> Frame3d.rotateAround Axis3d.x (Angle.radians (pi / 20))
-                |> Frame3d.moveTo (Point3d.fromMeters { x = 0, y = 0, z = 2.5 })
+                |> Frame3d.moveTo (Point3d.meters 0 0 2.5)
 
         originFrame3d =
             Frame3d.atPoint Point3d.origin

--- a/benchmarks/SphereConvex.elm
+++ b/benchmarks/SphereConvex.elm
@@ -31,7 +31,7 @@ suite : Benchmark
 suite =
     let
         center =
-            { x = 0, y = 0, z = 7 }
+            Point3d.meters 0 0 7
 
         radius =
             5
@@ -97,7 +97,7 @@ suite =
                         (\position ->
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 boxHull
@@ -113,7 +113,7 @@ suite =
                             {- Collision.OriginalSphereConvex.addContacts -}
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 originalBoxHull
@@ -127,7 +127,7 @@ suite =
                         (\position ->
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 boxHull
@@ -143,7 +143,7 @@ suite =
                             {- Collision.OriginalSphereConvex.addContacts -}
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 originalOctoHull
@@ -157,7 +157,7 @@ suite =
                         (\position ->
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 octoHull
@@ -173,7 +173,7 @@ suite =
                             {- Collision.OriginalSphereConvex.addContacts -}
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 originalOctoHull
@@ -187,7 +187,7 @@ suite =
                         (\position ->
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 octoHull

--- a/benchmarks/elm.json
+++ b/benchmarks/elm.json
@@ -4,7 +4,7 @@
         "../src",
         "."
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/core": "1.0.0",

--- a/elm.json
+++ b/elm.json
@@ -9,6 +9,7 @@
         "Physics.Body",
         "Physics.Material",
         "Physics.Constraint",
+        "Physics.Coordinates",
         "Physics.Shape",
         "Physics.Debug"
     ],

--- a/examples/Boxes.elm
+++ b/examples/Boxes.elm
@@ -154,11 +154,10 @@ addBoxes world =
                             box
                                 |> Body.setFrame3d
                                     (Frame3d.atPoint
-                                        (Point3d.fromMeters
-                                            { x = (x - (boxesPerDimension - 1) / 2) * distance
-                                            , y = (y - (boxesPerDimension - 1) / 2) * distance
-                                            , z = (z + (2 * boxesPerDimension + 1) / 2) * distance
-                                            }
+                                        (Point3d.meters
+                                            ((x - (boxesPerDimension - 1) / 2) * distance)
+                                            ((y - (boxesPerDimension - 1) / 2) * distance)
+                                            ((z + (2 * boxesPerDimension + 1) / 2) * distance)
                                         )
                                     )
                                 |> World.add
@@ -197,4 +196,4 @@ box =
     Meshes.box { x = 1, y = 1, z = 1 }
         |> Meshes.fromTriangles
         |> Body.block size size size
-        |> Body.setMass (Mass.kilograms 5)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 5))

--- a/examples/Boxes.elm
+++ b/examples/Boxes.elm
@@ -4,6 +4,7 @@ module Boxes exposing (main)
 Try changing `boxesPerDimension` to drop even more!
 -}
 
+import Acceleration
 import Browser
 import Common.Camera as Camera exposing (Camera)
 import Common.Events as Events
@@ -11,6 +12,8 @@ import Common.Fps as Fps
 import Common.Meshes as Meshes exposing (Meshes)
 import Common.Scene as Scene
 import Common.Settings as Settings exposing (Settings, SettingsMsg, settings)
+import Direction3d
+import Duration
 import Frame3d
 import Html exposing (Html)
 import Html.Events exposing (onClick)
@@ -79,7 +82,7 @@ update msg model =
         Tick dt ->
             ( { model
                 | fps = Fps.update dt model.fps
-                , world = World.simulate (1000 / 60) model.world
+                , world = World.simulate (Duration.seconds (1 / 60)) model.world
               }
             , Cmd.none
             )
@@ -128,7 +131,7 @@ view { settings, fps, world, camera } =
 initialWorld : World Meshes
 initialWorld =
     World.empty
-        |> World.setGravity { x = 0, y = 0, z = -10 }
+        |> World.setGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
         |> World.add floor
         |> addBoxes
 

--- a/examples/Car.elm
+++ b/examples/Car.elm
@@ -3,6 +3,7 @@ module Car exposing (main)
 {-| This shows how hinge constrains can be used to assemble a car.
 -}
 
+import Acceleration
 import Angle
 import Axis3d
 import Browser
@@ -13,6 +14,7 @@ import Common.Meshes as Meshes exposing (Meshes)
 import Common.Scene as Scene
 import Common.Settings as Settings exposing (Settings, SettingsMsg, settings)
 import Direction3d
+import Duration
 import Frame3d
 import Html exposing (Html)
 import Html.Events exposing (onClick)
@@ -90,7 +92,7 @@ update msg model =
                 , world =
                     model.world
                         |> World.constrain constrainCar
-                        |> World.simulate (1000 / 60)
+                        |> World.simulate (Duration.seconds (1 / 60))
               }
             , Cmd.none
             )
@@ -139,7 +141,7 @@ view { settings, fps, world, camera } =
 initialWorld : World Data
 initialWorld =
     World.empty
-        |> World.setGravity { x = 0, y = 0, z = -10 }
+        |> World.setGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
         |> World.add floor
         |> World.add slope
         |> addCar (Point3d.fromMeters { x = 0, y = 0, z = 5 })

--- a/examples/Car.elm
+++ b/examples/Car.elm
@@ -144,7 +144,7 @@ initialWorld =
         |> World.setGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
         |> World.add floor
         |> World.add slope
-        |> addCar (Point3d.fromMeters { x = 0, y = 0, z = 5 })
+        |> addCar (Point3d.meters 0 0 5)
 
 
 addCar : Point3d Meters WorldCoordinates -> World Data -> World Data
@@ -159,7 +159,7 @@ addCar offset world =
             (wheel "wheel1"
                 |> Body.setFrame3d
                     (Frame3d.translateBy
-                        (Vector3d.fromMeters { x = 3, y = 3, z = 0 })
+                        (Vector3d.meters 3 3 0)
                         originFrame
                     )
             )
@@ -167,7 +167,7 @@ addCar offset world =
             (wheel "wheel2"
                 |> Body.setFrame3d
                     (Frame3d.translateBy
-                        (Vector3d.fromMeters { x = -3, y = 3, z = 0 })
+                        (Vector3d.meters -3 3 0)
                         originFrame
                     )
             )
@@ -175,7 +175,7 @@ addCar offset world =
             (wheel "wheel3"
                 |> Body.setFrame3d
                     (Frame3d.translateBy
-                        (Vector3d.fromMeters { x = -3, y = -3, z = 0 })
+                        (Vector3d.meters -3 -3 0)
                         originFrame
                     )
             )
@@ -183,7 +183,7 @@ addCar offset world =
             (wheel "wheel4"
                 |> Body.setFrame3d
                     (Frame3d.translateBy
-                        (Vector3d.fromMeters { x = 3, y = -3, z = 0 })
+                        (Vector3d.meters 3 -3 0)
                         originFrame
                     )
             )
@@ -204,44 +204,44 @@ constrainCar b1 b2 =
         hinge1 =
             Constraint.hinge
                 (Axis3d.through
-                    (Point3d.fromMeters { x = 3, y = 3, z = 0 })
+                    (Point3d.meters 3 3 0)
                     (Direction3d.unsafe { x = dx, y = dy, z = 0 })
                 )
                 (Axis3d.through
-                    (Point3d.fromMeters { x = 0, y = 0, z = 0 })
+                    (Point3d.meters 0 0 0)
                     (Direction3d.unsafe { x = -1, y = 0, z = 0 })
                 )
 
         hinge2 =
             Constraint.hinge
                 (Axis3d.through
-                    (Point3d.fromMeters { x = -3, y = 3, z = 0 })
+                    (Point3d.meters -3 3 0)
                     (Direction3d.unsafe { x = -dx, y = -dy, z = 0 })
                 )
                 (Axis3d.through
-                    (Point3d.fromMeters { x = 0, y = 0, z = 0 })
+                    Point3d.origin
                     (Direction3d.unsafe { x = 1, y = 0, z = 0 })
                 )
 
         hinge3 =
             Constraint.hinge
                 (Axis3d.through
-                    (Point3d.fromMeters { x = -3, y = -3, z = 0 })
+                    (Point3d.meters -3 -3 0)
                     (Direction3d.unsafe { x = -1, y = 0, z = 0 })
                 )
                 (Axis3d.through
-                    (Point3d.fromMeters { x = 0, y = 0, z = 0 })
+                    Point3d.origin
                     (Direction3d.unsafe { x = 1, y = 0, z = 0 })
                 )
 
         hinge4 =
             Constraint.hinge
                 (Axis3d.through
-                    (Point3d.fromMeters { x = 3, y = -3, z = 0 })
+                    (Point3d.meters 3 -3 0)
                     (Direction3d.unsafe { x = 1, y = 0, z = 0 })
                 )
                 (Axis3d.through
-                    (Point3d.fromMeters { x = 0, y = 0, z = 0 })
+                    Point3d.origin
                     (Direction3d.unsafe { x = -1, y = 0, z = 0 })
                 )
     in
@@ -293,7 +293,7 @@ slope =
         |> Body.setFrame3d
             (Frame3d.atPoint Point3d.origin
                 |> Frame3d.rotateAround Axis3d.x (Angle.radians (pi / 16))
-                |> Frame3d.moveTo (Point3d.fromMeters { x = 0, y = -2, z = 1 })
+                |> Frame3d.moveTo (Point3d.meters 0 -2 1)
             )
 
 
@@ -308,7 +308,7 @@ base =
     in
     { name = "base", meshes = meshes }
         |> Body.block (Length.meters size.x) (Length.meters size.y) (Length.meters size.z)
-        |> Body.setMass (Mass.kilograms 1)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 1))
 
 
 wheel : String -> Body Data
@@ -322,4 +322,4 @@ wheel name =
     in
     { name = name, meshes = meshes }
         |> Body.sphere (Length.meters radius)
-        |> Body.setMass (Mass.kilograms 1)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 1))

--- a/examples/Car.elm
+++ b/examples/Car.elm
@@ -23,6 +23,7 @@ import Mass
 import Physics.Body as Body exposing (Body)
 import Physics.Constraint as Constraint exposing (Constraint)
 import Physics.Coordinates exposing (WorldCoordinates)
+import Physics.Shape as Shape
 import Physics.World as World exposing (World)
 import Point3d exposing (Point3d)
 import Vector3d
@@ -300,14 +301,24 @@ slope =
 base : Body Data
 base =
     let
-        size =
+        bottomSize =
             { x = 3, y = 6, z = 1 }
 
+        topSize =
+            { x = 2, y = 3, z = 1.5 }
+
+        topOffset =
+            { x = 0, y = 1, z = 1 }
+
         meshes =
-            Meshes.fromTriangles (Meshes.box size)
+            Meshes.fromTriangles (Meshes.box bottomSize ++ (Meshes.box topSize |> Meshes.moveBy topOffset))
     in
     { name = "base", meshes = meshes }
-        |> Body.block (Length.meters size.x) (Length.meters size.y) (Length.meters size.z)
+        |> Body.compound
+            [ Shape.block (Length.meters bottomSize.x) (Length.meters bottomSize.y) (Length.meters bottomSize.z)
+            , Shape.block (Length.meters topSize.x) (Length.meters topSize.y) (Length.meters topSize.z)
+                |> Shape.setFrame3d (Frame3d.atPoint (Point3d.fromMeters topOffset))
+            ]
         |> Body.setBehavior (Body.dynamic (Mass.kilograms 1))
 
 

--- a/examples/Cloth.elm
+++ b/examples/Cloth.elm
@@ -150,7 +150,7 @@ initialWorld =
     World.empty
         |> World.setGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
         |> World.add floor
-        |> World.add (Body.setFrame3d (Frame3d.atPoint (Point3d.fromMeters { x = 0, y = 0, z = 1 })) sphere)
+        |> World.add (Body.setFrame3d (Frame3d.atPoint (Point3d.meters 0 0 1)) sphere)
         |> addCloth
         |> World.constrain constrainCloth
 
@@ -168,11 +168,10 @@ addCloth world =
                     particle x y
                         |> Body.setFrame3d
                             (Frame3d.atPoint
-                                (Point3d.fromMeters
-                                    { x = (toFloat x - (toFloat particlesPerDimension - 1) / 2) * distanceBetweenParticles
-                                    , y = (toFloat y - (toFloat particlesPerDimension - 1) / 2) * distanceBetweenParticles
-                                    , z = 8
-                                    }
+                                (Point3d.meters
+                                    ((toFloat x - (toFloat particlesPerDimension - 1) / 2) * distanceBetweenParticles)
+                                    ((toFloat y - (toFloat particlesPerDimension - 1) / 2) * distanceBetweenParticles)
+                                    8
                                 )
                             )
                         |> World.add
@@ -231,7 +230,7 @@ sphere =
     , kind = Other
     }
         |> Body.sphere (Length.meters radius)
-        |> Body.setMass (Mass.kilograms 5)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 5))
 
 
 particle : Int -> Int -> Body Data
@@ -240,4 +239,4 @@ particle x y =
     , kind = Particle x y
     }
         |> Body.particle
-        |> Body.setMass (Mass.kilograms 5)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 5))

--- a/examples/Cloth.elm
+++ b/examples/Cloth.elm
@@ -4,6 +4,7 @@ module Cloth exposing (main)
 and distance constraints between adjacent points.
 -}
 
+import Acceleration
 import Browser
 import Common.Camera as Camera exposing (Camera)
 import Common.Events as Events
@@ -11,6 +12,8 @@ import Common.Fps as Fps
 import Common.Meshes as Meshes exposing (Meshes)
 import Common.Scene as Scene
 import Common.Settings as Settings exposing (Settings, SettingsMsg, settings)
+import Direction3d
+import Duration
 import Frame3d
 import Html exposing (Html)
 import Html.Events exposing (onClick)
@@ -96,7 +99,7 @@ update msg model =
         Tick dt ->
             ( { model
                 | fps = Fps.update dt model.fps
-                , world = World.simulate (1000 / 60) model.world
+                , world = World.simulate (Duration.seconds (1 / 60)) model.world
               }
             , Cmd.none
             )
@@ -145,7 +148,7 @@ view { settings, fps, world, camera } =
 initialWorld : World Data
 initialWorld =
     World.empty
-        |> World.setGravity { x = 0, y = 0, z = -10 }
+        |> World.setGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
         |> World.add floor
         |> World.add (Body.setFrame3d (Frame3d.atPoint (Point3d.fromMeters { x = 0, y = 0, z = 1 })) sphere)
         |> addCloth

--- a/examples/CollisionTest.elm
+++ b/examples/CollisionTest.elm
@@ -139,22 +139,22 @@ initialWorld =
                         |> Frame3d.rotateAround
                             (Axis3d.through Point3d.origin (Direction3d.unsafe { x = 0.7071, y = 0.7071, z = 0 }))
                             (Angle.radians (pi / 3))
-                        |> Frame3d.moveTo (Point3d.fromMeters { x = 0, y = 0, z = 10 })
+                        |> Frame3d.moveTo (Point3d.meters 0 0 10)
                     )
             )
         -- edge:
-        |> World.add (Body.setFrame3d (Frame3d.atPoint (Point3d.fromMeters { x = 4, y = 0, z = 0 })) sphere)
+        |> World.add (Body.setFrame3d (Frame3d.atPoint (Point3d.meters 4 0 0)) sphere)
         |> World.add
             (box
                 |> Body.setFrame3d
                     (Frame3d.atPoint Point3d.origin
                         |> Frame3d.rotateAround Axis3d.x (Angle.radians (pi / 3))
-                        |> Frame3d.moveTo (Point3d.fromMeters { x = 4, y = 0, z = 10 })
+                        |> Frame3d.moveTo (Point3d.meters 4 0 10)
                     )
             )
         -- face:
-        |> World.add (Body.setFrame3d (Frame3d.atPoint (Point3d.fromMeters { x = -4, y = 0, z = 0 })) sphere)
-        |> World.add (Body.setFrame3d (Frame3d.atPoint (Point3d.fromMeters { x = -4, y = 0, z = 10 })) box)
+        |> World.add (Body.setFrame3d (Frame3d.atPoint (Point3d.meters -4 0 0)) sphere)
+        |> World.add (Body.setFrame3d (Frame3d.atPoint (Point3d.meters -4 0 10)) box)
 
 
 {-| Shift the floor a little bit down
@@ -181,7 +181,7 @@ box =
     Meshes.box size
         |> Meshes.fromTriangles
         |> Body.block (Length.meters size.x) (Length.meters size.y) (Length.meters size.z)
-        |> Body.setMass (Mass.kilograms 5)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 5))
 
 
 sphere : Body Meshes

--- a/examples/CollisionTest.elm
+++ b/examples/CollisionTest.elm
@@ -4,6 +4,7 @@ module CollisionTest exposing (main)
 Note that spheres don’t move, that’s because they have zero mass.
 -}
 
+import Acceleration
 import Angle
 import Axis3d
 import Browser
@@ -14,6 +15,7 @@ import Common.Meshes as Meshes exposing (Meshes)
 import Common.Scene as Scene
 import Common.Settings as Settings exposing (Settings, SettingsMsg, settings)
 import Direction3d
+import Duration
 import Frame3d
 import Html exposing (Html)
 import Html.Events exposing (onClick)
@@ -77,7 +79,7 @@ update msg model =
         Tick dt ->
             ( { model
                 | fps = Fps.update dt model.fps
-                , world = World.simulate (1000 / 60) model.world
+                , world = World.simulate (Duration.seconds (1 / 60)) model.world
               }
             , Cmd.none
             )
@@ -126,7 +128,7 @@ view { settings, fps, world, camera } =
 initialWorld : World Meshes
 initialWorld =
     World.empty
-        |> World.setGravity { x = 0, y = 0, z = -10 }
+        |> World.setGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
         |> World.add floor
         -- corner:
         |> World.add sphere

--- a/examples/Common/Scene.elm
+++ b/examples/Common/Scene.elm
@@ -5,16 +5,20 @@ import Common.Math as Math
 import Common.Meshes as Meshes exposing (Meshes)
 import Common.Settings exposing (Settings)
 import Common.Shaders as Shaders
+import Frame3d
 import Geometry.Interop.LinearAlgebra.Direction3d as Direction3d
 import Geometry.Interop.LinearAlgebra.Frame3d as Frame3d
 import Geometry.Interop.LinearAlgebra.Point3d as Point3d
 import Html exposing (Html)
 import Html.Attributes as Attributes
+import Length exposing (Meters)
 import Math.Matrix4 as Mat4 exposing (Mat4)
 import Math.Vector3 as Vec3 exposing (Vec3)
 import Physics.Body as Body exposing (Body)
+import Physics.Coordinates exposing (WorldCoordinates)
 import Physics.Debug as Debug exposing (FaceNormal, UniqueEdge)
 import Physics.World as World exposing (RaycastResult, World)
+import Point3d exposing (Point3d)
 import WebGL exposing (Entity)
 
 
@@ -192,8 +196,8 @@ addBodyEntities ({ meshes, lightDirection, shadow, camera, debugWireframes, debu
 
 {-| Render collision point for the purpose of debugging
 -}
-addContactIndicator : SceneParams a -> { x : Float, y : Float, z : Float } -> List Entity -> List Entity
-addContactIndicator { lightDirection, camera } { x, y, z } tail =
+addContactIndicator : SceneParams a -> Point3d Meters WorldCoordinates -> List Entity -> List Entity
+addContactIndicator { lightDirection, camera } point tail =
     WebGL.entity
         Shaders.vertex
         Shaders.fragment
@@ -202,7 +206,7 @@ addContactIndicator { lightDirection, camera } { x, y, z } tail =
         , perspective = camera.perspectiveTransform
         , color = Vec3.vec3 1 0 0
         , lightDirection = lightDirection
-        , transform = Mat4.makeTranslate3 x y z
+        , transform = Frame3d.toMat4 (Frame3d.atPoint point)
         }
         :: tail
 

--- a/examples/Common/Scene.elm
+++ b/examples/Common/Scene.elm
@@ -49,6 +49,7 @@ view { settings, world, floorOffset, camera, raycastResult, meshes } =
             , debugWireframes = settings.debugWireframes
             , debugNormals = settings.debugNormals
             , debugEdges = settings.debugEdges
+            , debugCenterOfMass = settings.debugCenterOfMass
             , raycastResult = raycastResult
             , meshes = meshes
             , shadow =
@@ -95,6 +96,7 @@ type alias SceneParams a =
     , debugWireframes : Bool
     , debugNormals : Bool
     , debugEdges : Bool
+    , debugCenterOfMass : Bool
     , shadow : Maybe Mat4
     , raycastResult : Maybe (RaycastResult a)
     , meshes : a -> Meshes
@@ -102,7 +104,7 @@ type alias SceneParams a =
 
 
 addBodyEntities : SceneParams a -> Body a -> List Entity -> List Entity
-addBodyEntities ({ meshes, lightDirection, shadow, camera, debugWireframes, debugEdges, debugNormals, raycastResult } as sceneParams) body entities =
+addBodyEntities ({ meshes, lightDirection, shadow, camera, debugWireframes, debugCenterOfMass, debugEdges, debugNormals, raycastResult } as sceneParams) body entities =
     let
         transform =
             Frame3d.toMat4 (Body.getFrame3d body)
@@ -140,10 +142,18 @@ addBodyEntities ({ meshes, lightDirection, shadow, camera, debugWireframes, debu
             else
                 acc
 
+        addCenterOfMass acc =
+            if debugCenterOfMass then
+                addContactIndicator sceneParams (Point3d.placeIn (Body.getFrame3d body) (Debug.getCenterOfMass body)) acc
+
+            else
+                acc
+
         { mesh, wireframe } =
             meshes (Body.getData body)
     in
     entities
+        |> addCenterOfMass
         |> addEdges
         |> addNormals
         |> (if debugWireframes then

--- a/examples/Common/Settings.elm
+++ b/examples/Common/Settings.elm
@@ -20,6 +20,7 @@ type alias Settings =
     , debugNormals : Bool -- Set to True to see normal spikes
     , debugEdges : Bool -- Set to True to see edge markers
     , debugWireframes : Bool -- Set to True to see wireframes
+    , debugCenterOfMass : Bool -- Set to True to see center of mass
     , showFpsMeter : Bool
     , showSettings : Bool
     }
@@ -31,6 +32,7 @@ type SettingsMsg
     | ToggleEdges Bool
     | ToggleWireframes Bool
     | ToggleFpsMeter Bool
+    | ToggleCenterOfMass Bool
     | ToggleSettings
 
 
@@ -42,6 +44,7 @@ settings =
     , debugWireframes = False
     , showSettings = False
     , showFpsMeter = False
+    , debugCenterOfMass = False
     }
 
 
@@ -66,9 +69,12 @@ update msg model =
         ToggleFpsMeter showFpsMeter ->
             { model | showFpsMeter = showFpsMeter }
 
+        ToggleCenterOfMass debugCenterOfMass ->
+            { model | debugCenterOfMass = debugCenterOfMass }
+
 
 view : (SettingsMsg -> msg) -> Settings -> List (Html msg) -> Html msg
-view msg { showSettings, debugContacts, debugNormals, debugEdges, debugWireframes, showFpsMeter } extraContent =
+view msg { showSettings, debugContacts, debugNormals, debugEdges, debugWireframes, debugCenterOfMass, showFpsMeter } extraContent =
     Html.div
         [ style "position" "fixed"
         , style "right" "6px"
@@ -85,6 +91,7 @@ view msg { showSettings, debugContacts, debugNormals, debugEdges, debugWireframe
                 , style "border-radius" "0 0 4px 4px"
                 ]
                 ([ checkbox (ToggleContacts >> msg) debugContacts "collision points"
+                 , checkbox (ToggleCenterOfMass >> msg) debugCenterOfMass "center of mass"
                  , checkbox (ToggleNormals >> msg) debugNormals "normals"
                  , checkbox (ToggleEdges >> msg) debugEdges "unique edges"
                  , checkbox (ToggleWireframes >> msg) debugWireframes "wireframes"

--- a/examples/Dominoes.elm
+++ b/examples/Dominoes.elm
@@ -5,6 +5,7 @@ Without the slippy material, dominoes would not slide along each other.
 Try to make the floor slippy too!
 -}
 
+import Acceleration
 import Angle
 import Axis3d
 import Browser
@@ -14,6 +15,8 @@ import Common.Fps as Fps
 import Common.Meshes as Meshes exposing (Meshes)
 import Common.Scene as Scene
 import Common.Settings as Settings exposing (Settings, SettingsMsg, settings)
+import Direction3d
+import Duration
 import Frame3d
 import Html exposing (Html)
 import Html.Events exposing (onClick)
@@ -78,7 +81,7 @@ update msg model =
         Tick dt ->
             ( { model
                 | fps = Fps.update dt model.fps
-                , world = World.simulate (1000 / 60) model.world
+                , world = World.simulate (Duration.seconds (1 / 60)) model.world
               }
             , Cmd.none
             )
@@ -127,7 +130,7 @@ view { settings, fps, world, camera } =
 initialWorld : World Meshes
 initialWorld =
     World.empty
-        |> World.setGravity { x = 0, y = 0, z = -10 }
+        |> World.setGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
         |> World.add floor
         |> World.add
             (domino

--- a/examples/Dominoes.elm
+++ b/examples/Dominoes.elm
@@ -138,7 +138,7 @@ initialWorld =
                     (Frame3d.atPoint Point3d.origin
                         |> Frame3d.rotateAround Axis3d.y (Angle.radians (pi / 8))
                         |> Frame3d.rotateAround Axis3d.z (Angle.radians (pi / 4))
-                        |> Frame3d.moveTo (Point3d.fromMeters { x = -5.5, y = -5.5, z = 0 })
+                        |> Frame3d.moveTo (Point3d.meters -5.5 -5.5 0)
                     )
             )
         |> addDominos
@@ -152,13 +152,7 @@ addDominos world =
                 |> Body.setFrame3d
                     (Frame3d.atPoint Point3d.origin
                         |> Frame3d.rotateAround Axis3d.z (Angle.radians (pi / 4))
-                        |> Frame3d.moveTo
-                            (Point3d.fromMeters
-                                { x = toFloat (5 - i)
-                                , y = toFloat (5 - i)
-                                , z = 0
-                                }
-                            )
+                        |> Frame3d.moveTo (Point3d.meters (toFloat (5 - i)) (toFloat (5 - i)) 0)
                     )
                 |> World.add
         )
@@ -192,7 +186,7 @@ domino =
     Meshes.box size
         |> Meshes.fromTriangles
         |> Body.block (Length.meters size.x) (Length.meters size.y) (Length.meters size.z)
-        |> Body.setMass (Mass.kilograms 5)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 5))
         |> Body.setMaterial slippy
 
 

--- a/examples/Drag.elm
+++ b/examples/Drag.elm
@@ -133,12 +133,24 @@ update msg model =
             ( { model | world = initialWorld }, Cmd.none )
 
         MouseDown direction ->
-            case
-                World.raycast
-                    (Point3d.fromMeters model.camera.from)
-                    (Direction3d.unsafe direction)
+            let
+                maybeRaycastResult =
                     model.world
-            of
+                        |> World.raycast
+                            (Point3d.fromMeters model.camera.from)
+                            (Direction3d.unsafe direction)
+                        |> Maybe.andThen
+                            -- only allow clicks on boxes
+                            (\result ->
+                                case (Body.getData result.body).id of
+                                    Box _ ->
+                                        Just result
+
+                                    _ ->
+                                        Nothing
+                            )
+            in
+            case maybeRaycastResult of
                 Just raycastResult ->
                     -- create temporary body and constrain it
                     -- with selected body

--- a/examples/Drag.elm
+++ b/examples/Drag.elm
@@ -10,6 +10,7 @@ module Drag exposing (main)
 
 -}
 
+import Acceleration
 import Angle
 import Axis3d
 import Browser
@@ -20,6 +21,7 @@ import Common.Meshes as Meshes exposing (Meshes)
 import Common.Scene as Scene
 import Common.Settings as Settings exposing (Settings, SettingsMsg, settings)
 import Direction3d
+import Duration
 import Frame3d
 import Geometry.Interop.LinearAlgebra.Frame3d as Frame3d
 import Html exposing (Html)
@@ -117,7 +119,7 @@ update msg model =
                 | fps = Fps.update dt model.fps
                 , world =
                     model.world
-                        |> World.simulate (1000 / 60)
+                        |> World.simulate (Duration.seconds (1 / 60))
               }
             , Cmd.none
             )
@@ -273,7 +275,7 @@ view { settings, fps, world, camera, selection } =
 initialWorld : World Data
 initialWorld =
     World.empty
-        |> World.setGravity { x = 0, y = 0, z = -10 }
+        |> World.setGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
         |> World.add floor
         |> World.add
             (box 1

--- a/examples/Drag.elm
+++ b/examples/Drag.elm
@@ -159,7 +159,7 @@ update msg model =
                                     (\b1 b2 ->
                                         if (Body.getData b1).id == Mouse && (Body.getData b2).id == (Body.getData raycastResult.body).id then
                                             [ Constraint.pointToPoint
-                                                (Point3d.fromMeters { x = 0, y = 0, z = 0 })
+                                                Point3d.origin
                                                 raycastResult.point
                                             ]
 
@@ -282,19 +282,19 @@ initialWorld =
                 |> Body.setFrame3d
                     (Frame3d.atPoint Point3d.origin
                         |> Frame3d.rotateAround Axis3d.y (Angle.radians (-pi / 5))
-                        |> Frame3d.moveTo (Point3d.fromMeters { x = 0, y = 0, z = 2 })
+                        |> Frame3d.moveTo (Point3d.meters 0 0 2)
                     )
             )
         |> World.add
             (box 2
-                |> Body.setFrame3d (Frame3d.atPoint (Point3d.fromMeters { x = 0.5, y = 0, z = 8 }))
+                |> Body.setFrame3d (Frame3d.atPoint (Point3d.meters 0.5 0 8))
             )
         |> World.add
             (box 3
                 |> Body.setFrame3d
                     (Frame3d.atPoint Point3d.origin
                         |> Frame3d.rotateAround (Axis3d.through Point3d.origin (Direction3d.unsafe { x = 0.7071, y = 0.7071, z = 0 })) (Angle.radians (pi / 5))
-                        |> Frame3d.moveTo (Point3d.fromMeters { x = -1.2, y = 0, z = 5 })
+                        |> Frame3d.moveTo (Point3d.meters -1.2 0 5)
                     )
             )
 
@@ -328,7 +328,7 @@ box id =
     in
     { id = Box id, meshes = meshes }
         |> Body.block (Length.meters size.x) (Length.meters size.y) (Length.meters size.z)
-        |> Body.setMass (Mass.kilograms 10)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 10))
 
 
 {-| An empty body with zero mass, rendered as a sphere.

--- a/examples/Randomize.elm
+++ b/examples/Randomize.elm
@@ -218,18 +218,22 @@ compound =
 
         boxShape =
             Shape.block (Length.meters size.x) (Length.meters size.y) (Length.meters size.z)
-    in
-    [ Meshes.moveBy { x = -0.5, y = 0, z = -0.5 } boxTriangles
-    , Meshes.moveBy { x = -0.5, y = 0, z = 0.5 } boxTriangles
-    , Meshes.moveBy { x = 0.5, y = 0, z = 0.5 } boxTriangles
-    ]
-        |> List.concat
-        |> Meshes.fromTriangles
-        |> Body.compound
-            [ Shape.setFrame3d (Frame3d.atPoint (Point3d.meters -0.5 0 -0.5)) boxShape
-            , Shape.setFrame3d (Frame3d.atPoint (Point3d.meters -0.5 0 0.5)) boxShape
-            , Shape.setFrame3d (Frame3d.atPoint (Point3d.meters 0.5 0 0.5)) boxShape
+
+        coordinates =
+            [ Point3d.meters -0.5 0 -0.5
+            , Point3d.meters -0.5 0 0.5
+            , Point3d.meters 0.5 0 0.5
             ]
+
+        shapes =
+            List.map (\p -> Shape.setFrame3d (Frame3d.atPoint p) boxShape) coordinates
+
+        compoundTriangles =
+            List.concatMap
+                (\p -> Meshes.moveBy (Point3d.toMeters p) boxTriangles)
+                coordinates
+    in
+    Body.compound shapes (Meshes.fromTriangles compoundTriangles)
         |> Body.setBehavior (Body.dynamic (Mass.kilograms 5))
 
 

--- a/examples/Randomize.elm
+++ b/examples/Randomize.elm
@@ -5,6 +5,7 @@ It also shows how to make a compound body out of multiple shapes.
 If you click too fast, the bodies may be spawned inside each other.
 -}
 
+import Acceleration
 import Angle
 import Axis3d
 import Browser
@@ -15,6 +16,7 @@ import Common.Meshes as Meshes exposing (Meshes)
 import Common.Scene as Scene
 import Common.Settings as Settings exposing (Settings, SettingsMsg, settings)
 import Direction3d
+import Duration
 import Frame3d
 import Html exposing (Html)
 import Html.Events exposing (onClick)
@@ -83,7 +85,7 @@ update msg model =
         Tick dt ->
             ( { model
                 | fps = Fps.update dt model.fps
-                , world = World.simulate (1000 / 60) model.world
+                , world = World.simulate (Duration.seconds (1 / 60)) model.world
               }
             , Cmd.none
             )
@@ -140,7 +142,7 @@ view { settings, fps, world, camera } =
 initialWorld : World Meshes
 initialWorld =
     World.empty
-        |> World.setGravity { x = 0, y = 0, z = -10 }
+        |> World.setGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
         |> World.add floor
         |> World.add
             (box

--- a/examples/Randomize.elm
+++ b/examples/Randomize.elm
@@ -149,19 +149,19 @@ initialWorld =
                 |> Body.setFrame3d
                     (Frame3d.atPoint Point3d.origin
                         |> Frame3d.rotateAround Axis3d.y (Angle.radians (-pi / 5))
-                        |> Frame3d.moveTo (Point3d.fromMeters { x = 0, y = 0, z = 2 })
+                        |> Frame3d.moveTo (Point3d.meters 0 0 2)
                     )
             )
         |> World.add
             (sphere
-                |> Body.setFrame3d (Frame3d.atPoint (Point3d.fromMeters { x = 0.5, y = 0, z = 8 }))
+                |> Body.setFrame3d (Frame3d.atPoint (Point3d.meters 0.5 0 8))
             )
         |> World.add
             (compound
                 |> Body.setFrame3d
                     (Frame3d.atPoint Point3d.origin
                         |> Frame3d.rotateAround (Axis3d.through Point3d.origin (Direction3d.unsafe { x = 0.7071, y = 0.7071, z = 0 })) (Angle.radians (pi / 5))
-                        |> Frame3d.moveTo (Point3d.fromMeters { x = -1.2, y = 0, z = 5 })
+                        |> Frame3d.moveTo (Point3d.meters -1.2 0 5)
                     )
             )
 
@@ -190,7 +190,7 @@ box =
     Meshes.box size
         |> Meshes.fromTriangles
         |> Body.block (Length.meters size.x) (Length.meters size.y) (Length.meters size.z)
-        |> Body.setMass (Mass.kilograms 5)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 5))
 
 
 sphere : Body Meshes
@@ -202,7 +202,7 @@ sphere =
     Meshes.sphere 2 radius
         |> Meshes.fromTriangles
         |> Body.sphere (Length.meters radius)
-        |> Body.setMass (Mass.kilograms 5)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 5))
 
 
 {-| A compound body made of three boxes
@@ -226,11 +226,11 @@ compound =
         |> List.concat
         |> Meshes.fromTriangles
         |> Body.compound
-            [ Shape.setFrame3d (Frame3d.atPoint (Point3d.fromMeters { x = -0.5, y = 0, z = -0.5 })) boxShape
-            , Shape.setFrame3d (Frame3d.atPoint (Point3d.fromMeters { x = -0.5, y = 0, z = 0.5 })) boxShape
-            , Shape.setFrame3d (Frame3d.atPoint (Point3d.fromMeters { x = 0.5, y = 0, z = 0.5 })) boxShape
+            [ Shape.setFrame3d (Frame3d.atPoint (Point3d.meters -0.5 0 -0.5)) boxShape
+            , Shape.setFrame3d (Frame3d.atPoint (Point3d.meters -0.5 0 0.5)) boxShape
+            , Shape.setFrame3d (Frame3d.atPoint (Point3d.meters 0.5 0 0.5)) boxShape
             ]
-        |> Body.setMass (Mass.kilograms 5)
+        |> Body.setBehavior (Body.dynamic (Mass.kilograms 5))
 
 
 {-| A random body raised above the plane, shifted or rotated to a random 3d angle
@@ -251,9 +251,10 @@ randomBody =
             )
                 |> Body.setFrame3d
                     (Frame3d.atPoint Point3d.origin
-                        |> Frame3d.rotateAround (Axis3d.through Point3d.origin (Maybe.withDefault Direction3d.x (Vector3d.direction (Vector3d.from Point3d.origin (Point3d.fromMeters { x = x, y = y, z = z })))))
+                        |> Frame3d.rotateAround
+                            (Axis3d.through Point3d.origin (Maybe.withDefault Direction3d.x (Vector3d.direction (Vector3d.from Point3d.origin (Point3d.meters x y z)))))
                             (Angle.radians angle)
-                        |> Frame3d.moveTo (Point3d.fromMeters { x = 0, y = 0, z = 10 })
+                        |> Frame3d.moveTo (Point3d.meters 0 0 10)
                     )
         )
         (Random.float (-pi / 2) (pi / 2))

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -4,7 +4,7 @@
         ".",
         "../src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.0",

--- a/src/Fixtures/NarrowPhase.elm
+++ b/src/Fixtures/NarrowPhase.elm
@@ -7,13 +7,19 @@ module Fixtures.NarrowPhase exposing
 import Internal.Const as Const
 import Internal.Contact exposing (Contact)
 import Internal.Vector3 as Vec3 exposing (Vec3)
+import Length exposing (Meters)
+import Physics.Coordinates exposing (WorldCoordinates)
+import Point3d exposing (Point3d)
 
 
-sphereContactBoxPositions : Vec3 -> Float -> Float -> List ( Vec3, List Contact )
-sphereContactBoxPositions center radius boxHalfExtent =
+sphereContactBoxPositions : Point3d Meters WorldCoordinates -> Float -> Float -> List ( Vec3, List Contact )
+sphereContactBoxPositions c radius boxHalfExtent =
     let
         delta =
             3 * Const.precision
+
+        center =
+            Point3d.toMeters c
 
         nearEdgeOffset =
             boxHalfExtent - delta
@@ -102,11 +108,14 @@ sphereContactBoxPositions center radius boxHalfExtent =
     ]
 
 
-sphereContactOctohedronPositions : Vec3 -> Float -> Float -> List ( Vec3, List Contact )
-sphereContactOctohedronPositions center radius octoHalfExtent =
+sphereContactOctohedronPositions : Point3d Meters WorldCoordinates -> Float -> Float -> List ( Vec3, List Contact )
+sphereContactOctohedronPositions c radius octoHalfExtent =
     let
         delta =
             3 * Const.precision
+
+        center =
+            Point3d.toMeters c
 
         -- Reposition the octohedron so that it contacts the sphere at each:
         -- vertex

--- a/src/Internal/AABB.elm
+++ b/src/Internal/AABB.elm
@@ -13,9 +13,9 @@ import Direction3d
 import Frame3d exposing (Frame3d)
 import Internal.Const as Const
 import Internal.Convex exposing (Convex)
-import Internal.Coordinates exposing (BodyLocalCoordinates, ShapeLocalCoordinates)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
+import Physics.Coordinates exposing (BodyCoordinates, ShapeCoordinates)
 import Point3d
 
 
@@ -83,7 +83,7 @@ extend aabb1 aabb =
     }
 
 
-convex : Convex -> Frame3d Meters BodyLocalCoordinates { defines : ShapeLocalCoordinates } -> AABB
+convex : Convex -> Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> AABB
 convex { vertices } frame3d =
     List.foldl
         (\point ->
@@ -102,7 +102,7 @@ dimensions { lowerBound, upperBound } =
     Vec3.sub upperBound lowerBound
 
 
-plane : Frame3d Meters BodyLocalCoordinates { defines : ShapeLocalCoordinates } -> AABB
+plane : Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> AABB
 plane frame3d =
     let
         { x, y, z } =
@@ -142,7 +142,7 @@ plane frame3d =
         maximum
 
 
-particle : Frame3d Meters BodyLocalCoordinates { defines : ShapeLocalCoordinates } -> AABB
+particle : Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> AABB
 particle frame3d =
     let
         position =
@@ -153,7 +153,7 @@ particle frame3d =
     }
 
 
-sphere : Float -> Frame3d Meters BodyLocalCoordinates { defines : ShapeLocalCoordinates } -> AABB
+sphere : Float -> Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> AABB
 sphere radius frame3d =
     let
         c =

--- a/src/Internal/AABB.elm
+++ b/src/Internal/AABB.elm
@@ -15,7 +15,7 @@ import Internal.Const as Const
 import Internal.Convex exposing (Convex)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
-import Physics.Coordinates exposing (BodyCoordinates, ShapeCoordinates)
+import Physics.Coordinates exposing (CenterOfMassCoordinates, ShapeCoordinates)
 import Point3d
 
 
@@ -83,7 +83,7 @@ extend aabb1 aabb =
     }
 
 
-convex : Convex -> Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> AABB
+convex : Convex -> Frame3d Meters CenterOfMassCoordinates { defines : ShapeCoordinates } -> AABB
 convex { vertices } frame3d =
     List.foldl
         (\point ->
@@ -102,7 +102,7 @@ dimensions { lowerBound, upperBound } =
     Vec3.sub upperBound lowerBound
 
 
-plane : Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> AABB
+plane : Frame3d Meters CenterOfMassCoordinates { defines : ShapeCoordinates } -> AABB
 plane frame3d =
     let
         { x, y, z } =
@@ -142,7 +142,7 @@ plane frame3d =
         maximum
 
 
-particle : Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> AABB
+particle : Frame3d Meters CenterOfMassCoordinates { defines : ShapeCoordinates } -> AABB
 particle frame3d =
     let
         position =
@@ -153,7 +153,7 @@ particle frame3d =
     }
 
 
-sphere : Float -> Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> AABB
+sphere : Float -> Frame3d Meters CenterOfMassCoordinates { defines : ShapeCoordinates } -> AABB
 sphere radius frame3d =
     let
         c =

--- a/src/Internal/AABB.elm
+++ b/src/Internal/AABB.elm
@@ -13,9 +13,10 @@ import Direction3d
 import Frame3d exposing (Frame3d)
 import Internal.Const as Const
 import Internal.Convex exposing (Convex)
+import Internal.Coordinates exposing (CenterOfMassCoordinates)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
-import Physics.Coordinates exposing (CenterOfMassCoordinates, ShapeCoordinates)
+import Physics.Coordinates exposing (ShapeCoordinates)
 import Point3d
 
 

--- a/src/Internal/Body.elm
+++ b/src/Internal/Body.elm
@@ -13,12 +13,12 @@ import Axis3d
 import Direction3d
 import Frame3d exposing (Frame3d)
 import Internal.AABB as AABB exposing (AABB)
-import Internal.Coordinates exposing (BodyLocalCoordinates, WorldCoordinates)
 import Internal.Material as Material exposing (Material)
 import Internal.Matrix3 as Mat3 exposing (Mat3)
 import Internal.Shape as Shape exposing (Shape)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
+import Physics.Coordinates exposing (BodyCoordinates, WorldCoordinates)
 import Point3d
 import Vector3d
 
@@ -31,7 +31,7 @@ type alias Body data =
     { id : Int
     , data : data
     , material : Material
-    , frame3d : Frame3d Meters WorldCoordinates { defines : BodyLocalCoordinates }
+    , frame3d : Frame3d Meters WorldCoordinates { defines : BodyCoordinates }
     , velocity : Vec3
     , angularVelocity : Vec3
     , mass : Float
@@ -71,7 +71,7 @@ compound shapes data =
         }
 
 
-defaultFrame : Frame3d Meters WorldCoordinates { defines : BodyLocalCoordinates }
+defaultFrame : Frame3d Meters WorldCoordinates { defines : BodyCoordinates }
 defaultFrame =
     Frame3d.atPoint Point3d.origin
 
@@ -215,7 +215,7 @@ updateMassProperties ({ mass } as body) =
     }
 
 
-updateInvInertiaWorld : Bool -> Vec3 -> Frame3d Meters WorldCoordinates { defines : BodyLocalCoordinates } -> Mat3 -> Mat3
+updateInvInertiaWorld : Bool -> Vec3 -> Frame3d Meters WorldCoordinates { defines : BodyCoordinates } -> Mat3 -> Mat3
 updateInvInertiaWorld force invInertia frame3d invInertiaWorld =
     if not force && invInertia.x == invInertia.y && invInertia.y == invInertia.z then
         invInertiaWorld

--- a/src/Internal/Body.elm
+++ b/src/Internal/Body.elm
@@ -2,6 +2,7 @@ module Internal.Body exposing
     ( Body
     , Protected(..)
     , addGravity
+    , centerOfMass
     , compound
     , raycast
     , update
@@ -18,8 +19,8 @@ import Internal.Matrix3 as Mat3 exposing (Mat3)
 import Internal.Shape as Shape exposing (Shape)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
-import Physics.Coordinates exposing (BodyCoordinates, WorldCoordinates)
-import Point3d
+import Physics.Coordinates exposing (BodyCoordinates, CenterOfMassCoordinates, WorldCoordinates)
+import Point3d exposing (Point3d)
 import Vector3d
 
 
@@ -31,11 +32,12 @@ type alias Body data =
     { id : Int
     , data : data
     , material : Material
-    , frame3d : Frame3d Meters WorldCoordinates { defines : BodyCoordinates }
+    , frame3d : Frame3d Meters WorldCoordinates { defines : CenterOfMassCoordinates }
+    , centerOfMassFrame3d : Frame3d Meters BodyCoordinates { defines : CenterOfMassCoordinates }
     , velocity : Vec3
     , angularVelocity : Vec3
     , mass : Float
-    , shapes : List Shape
+    , shapes : List (Shape CenterOfMassCoordinates)
     , force : Vec3
     , torque : Vec3
     , boundingSphereRadius : Float
@@ -48,20 +50,72 @@ type alias Body data =
     }
 
 
-compound : List Shape -> data -> Body data
+centerOfMass : List (Shape BodyCoordinates) -> Point3d Meters BodyCoordinates
+centerOfMass shapes =
+    let
+        totalVolume =
+            List.foldl (\{ volume } sum -> sum + volume) 0 shapes
+    in
+    if totalVolume > 0 then
+        Point3d.fromMeters
+            (List.foldl
+                (\shape ->
+                    Vec3.add
+                        (Vec3.scale
+                            (shape.volume / totalVolume)
+                            (Point3d.toMeters (Frame3d.originPoint shape.frame3d))
+                        )
+                )
+                Vec3.zero
+                shapes
+            )
+
+    else
+        Point3d.origin
+
+
+compound : List (Shape BodyCoordinates) -> data -> Body data
 compound shapes data =
+    let
+        centerOfMassPoint =
+            centerOfMass shapes
+
+        centerOfMassFrame3d : Frame3d Meters BodyCoordinates { defines : CenterOfMassCoordinates }
+        centerOfMassFrame3d =
+            Frame3d.atPoint centerOfMassPoint
+
+        bodyFrame3d : Frame3d Meters WorldCoordinates { defines : BodyCoordinates }
+        bodyFrame3d =
+            Frame3d.atPoint Point3d.origin
+
+        frame3d : Frame3d Meters WorldCoordinates { defines : CenterOfMassCoordinates }
+        frame3d =
+            Frame3d.placeIn bodyFrame3d centerOfMassFrame3d
+
+        movedShapes : List (Shape CenterOfMassCoordinates)
+        movedShapes =
+            List.map
+                (\shape ->
+                    { kind = shape.kind
+                    , volume = shape.volume
+                    , frame3d = Frame3d.relativeTo centerOfMassFrame3d shape.frame3d
+                    }
+                )
+                shapes
+    in
     updateMassProperties
         { id = -1
         , data = data
         , material = Material.default
-        , frame3d = defaultFrame
+        , frame3d = frame3d
+        , centerOfMassFrame3d = centerOfMassFrame3d
         , velocity = Vec3.zero
         , angularVelocity = Vec3.zero
         , mass = 0
-        , shapes = shapes
+        , shapes = movedShapes
         , force = Vec3.zero
         , torque = Vec3.zero
-        , boundingSphereRadius = List.foldl Shape.expandBoundingSphereRadius 0 shapes
+        , boundingSphereRadius = List.foldl Shape.expandBoundingSphereRadius 0 movedShapes
 
         -- mass props
         , invMass = 0
@@ -69,11 +123,6 @@ compound shapes data =
         , invInertia = Vec3.zero
         , invInertiaWorld = Mat3.identity
         }
-
-
-defaultFrame : Frame3d Meters WorldCoordinates { defines : BodyCoordinates }
-defaultFrame =
-    Frame3d.atPoint Point3d.origin
 
 
 addGravity : Vec3 -> Body data -> Body data
@@ -137,6 +186,7 @@ update dt vlambda wlambda body =
     , velocity = newVelocity
     , angularVelocity = newAngularVelocity
     , frame3d = newFrame3d
+    , centerOfMassFrame3d = body.centerOfMassFrame3d
     , mass = body.mass
     , shapes = body.shapes
     , boundingSphereRadius = body.boundingSphereRadius
@@ -215,7 +265,7 @@ updateMassProperties ({ mass } as body) =
     }
 
 
-updateInvInertiaWorld : Bool -> Vec3 -> Frame3d Meters WorldCoordinates { defines : BodyCoordinates } -> Mat3 -> Mat3
+updateInvInertiaWorld : Bool -> Vec3 -> Frame3d Meters WorldCoordinates { defines : CenterOfMassCoordinates } -> Mat3 -> Mat3
 updateInvInertiaWorld force invInertia frame3d invInertiaWorld =
     if not force && invInertia.x == invInertia.y && invInertia.y == invInertia.z then
         invInertiaWorld

--- a/src/Internal/Body.elm
+++ b/src/Internal/Body.elm
@@ -14,12 +14,13 @@ import Axis3d
 import Direction3d
 import Frame3d exposing (Frame3d)
 import Internal.AABB as AABB exposing (AABB)
+import Internal.Coordinates exposing (CenterOfMassCoordinates)
 import Internal.Material as Material exposing (Material)
 import Internal.Matrix3 as Mat3 exposing (Mat3)
 import Internal.Shape as Shape exposing (Shape)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
-import Physics.Coordinates exposing (BodyCoordinates, CenterOfMassCoordinates, WorldCoordinates)
+import Physics.Coordinates exposing (BodyCoordinates, WorldCoordinates)
 import Point3d exposing (Point3d)
 import Vector3d
 

--- a/src/Internal/Constraint.elm
+++ b/src/Internal/Constraint.elm
@@ -2,9 +2,10 @@ module Internal.Constraint exposing (Constraint(..), ConstraintGroup, relativeTo
 
 import Direction3d
 import Frame3d exposing (Frame3d)
+import Internal.Coordinates exposing (CenterOfMassCoordinates)
 import Internal.Vector3 exposing (Vec3)
 import Length exposing (Meters)
-import Physics.Coordinates exposing (BodyCoordinates, CenterOfMassCoordinates)
+import Physics.Coordinates exposing (BodyCoordinates)
 import Point3d
 
 

--- a/src/Internal/Constraint.elm
+++ b/src/Internal/Constraint.elm
@@ -1,9 +1,14 @@
-module Internal.Constraint exposing (Constraint(..), ConstraintGroup)
+module Internal.Constraint exposing (Constraint(..), ConstraintGroup, relativeToCenterOfMass)
 
+import Direction3d
+import Frame3d exposing (Frame3d)
 import Internal.Vector3 exposing (Vec3)
+import Length exposing (Meters)
+import Physics.Coordinates exposing (BodyCoordinates, CenterOfMassCoordinates)
+import Point3d
 
 
-type Constraint
+type Constraint coordinates
     = PointToPoint
         { pivot1 : Vec3
         , pivot2 : Vec3
@@ -20,5 +25,30 @@ type Constraint
 type alias ConstraintGroup =
     { bodyId1 : Int
     , bodyId2 : Int
-    , constraints : List Constraint
+    , constraints : List (Constraint CenterOfMassCoordinates)
     }
+
+
+relativeToCenterOfMass :
+    Frame3d Meters BodyCoordinates { defines : CenterOfMassCoordinates }
+    -> Frame3d Meters BodyCoordinates { defines : CenterOfMassCoordinates }
+    -> Constraint BodyCoordinates
+    -> Constraint CenterOfMassCoordinates
+relativeToCenterOfMass centerOfMassFrame3d1 centerOfMassFrame3d2 constraint =
+    case constraint of
+        PointToPoint { pivot1, pivot2 } ->
+            PointToPoint
+                { pivot1 = Point3d.toMeters (Point3d.relativeTo centerOfMassFrame3d1 (Point3d.fromMeters pivot1))
+                , pivot2 = Point3d.toMeters (Point3d.relativeTo centerOfMassFrame3d2 (Point3d.fromMeters pivot2))
+                }
+
+        Hinge { pivot1, axis1, pivot2, axis2 } ->
+            Hinge
+                { pivot1 = Point3d.toMeters (Point3d.relativeTo centerOfMassFrame3d1 (Point3d.fromMeters pivot1))
+                , axis1 = Direction3d.unwrap (Direction3d.relativeTo centerOfMassFrame3d1 (Direction3d.unsafe axis1))
+                , pivot2 = Point3d.toMeters (Point3d.relativeTo centerOfMassFrame3d2 (Point3d.fromMeters pivot2))
+                , axis2 = Direction3d.unwrap (Direction3d.relativeTo centerOfMassFrame3d1 (Direction3d.unsafe axis2))
+                }
+
+        Distance length ->
+            Distance length

--- a/src/Internal/Constraint.elm
+++ b/src/Internal/Constraint.elm
@@ -1,4 +1,4 @@
-module Internal.Constraint exposing (Constraint(..), ConstraintGroup, relativeToCenterOfMass)
+module Internal.Constraint exposing (Constraint(..), ConstraintGroup, Protected(..), relativeToCenterOfMass)
 
 import Axis3d exposing (Axis3d)
 import Frame3d exposing (Frame3d)
@@ -6,6 +6,10 @@ import Internal.Coordinates exposing (CenterOfMassCoordinates)
 import Length exposing (Length, Meters)
 import Physics.Coordinates exposing (BodyCoordinates)
 import Point3d exposing (Point3d)
+
+
+type Protected
+    = Protected (Constraint BodyCoordinates)
 
 
 type Constraint coordinates
@@ -24,9 +28,9 @@ type alias ConstraintGroup =
 relativeToCenterOfMass :
     Frame3d Meters BodyCoordinates { defines : CenterOfMassCoordinates }
     -> Frame3d Meters BodyCoordinates { defines : CenterOfMassCoordinates }
-    -> Constraint BodyCoordinates
+    -> Protected
     -> Constraint CenterOfMassCoordinates
-relativeToCenterOfMass centerOfMassFrame3d1 centerOfMassFrame3d2 constraint =
+relativeToCenterOfMass centerOfMassFrame3d1 centerOfMassFrame3d2 (Protected constraint) =
     case constraint of
         PointToPoint pivot1 pivot2 ->
             PointToPoint

--- a/src/Internal/Constraint.elm
+++ b/src/Internal/Constraint.elm
@@ -1,26 +1,17 @@
 module Internal.Constraint exposing (Constraint(..), ConstraintGroup, relativeToCenterOfMass)
 
-import Direction3d
+import Axis3d exposing (Axis3d)
 import Frame3d exposing (Frame3d)
 import Internal.Coordinates exposing (CenterOfMassCoordinates)
-import Internal.Vector3 exposing (Vec3)
-import Length exposing (Meters)
+import Length exposing (Length, Meters)
 import Physics.Coordinates exposing (BodyCoordinates)
-import Point3d
+import Point3d exposing (Point3d)
 
 
 type Constraint coordinates
-    = PointToPoint
-        { pivot1 : Vec3
-        , pivot2 : Vec3
-        }
-    | Hinge
-        { pivot1 : Vec3
-        , axis1 : Vec3
-        , pivot2 : Vec3
-        , axis2 : Vec3
-        }
-    | Distance Float
+    = PointToPoint (Point3d Meters coordinates) (Point3d Meters coordinates)
+    | Hinge (Axis3d Meters coordinates) (Axis3d Meters coordinates)
+    | Distance Length
 
 
 type alias ConstraintGroup =
@@ -37,19 +28,15 @@ relativeToCenterOfMass :
     -> Constraint CenterOfMassCoordinates
 relativeToCenterOfMass centerOfMassFrame3d1 centerOfMassFrame3d2 constraint =
     case constraint of
-        PointToPoint { pivot1, pivot2 } ->
+        PointToPoint pivot1 pivot2 ->
             PointToPoint
-                { pivot1 = Point3d.toMeters (Point3d.relativeTo centerOfMassFrame3d1 (Point3d.fromMeters pivot1))
-                , pivot2 = Point3d.toMeters (Point3d.relativeTo centerOfMassFrame3d2 (Point3d.fromMeters pivot2))
-                }
+                (Point3d.relativeTo centerOfMassFrame3d1 pivot1)
+                (Point3d.relativeTo centerOfMassFrame3d2 pivot2)
 
-        Hinge { pivot1, axis1, pivot2, axis2 } ->
+        Hinge axis1 axis2 ->
             Hinge
-                { pivot1 = Point3d.toMeters (Point3d.relativeTo centerOfMassFrame3d1 (Point3d.fromMeters pivot1))
-                , axis1 = Direction3d.unwrap (Direction3d.relativeTo centerOfMassFrame3d1 (Direction3d.unsafe axis1))
-                , pivot2 = Point3d.toMeters (Point3d.relativeTo centerOfMassFrame3d2 (Point3d.fromMeters pivot2))
-                , axis2 = Direction3d.unwrap (Direction3d.relativeTo centerOfMassFrame3d1 (Direction3d.unsafe axis2))
-                }
+                (Axis3d.relativeTo centerOfMassFrame3d1 axis1)
+                (Axis3d.relativeTo centerOfMassFrame3d2 axis2)
 
         Distance length ->
             Distance length

--- a/src/Internal/Convex.elm
+++ b/src/Internal/Convex.elm
@@ -20,7 +20,7 @@ import Direction3d
 import Frame3d exposing (Frame3d)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
-import Physics.Coordinates exposing (BodyCoordinates, ShapeCoordinates, WorldCoordinates)
+import Physics.Coordinates exposing (CenterOfMassCoordinates, ShapeCoordinates, WorldCoordinates)
 import Point3d
 import Set
 
@@ -367,7 +367,7 @@ foldUniqueEdges fn acc { vertices, uniqueEdges } =
             acc
 
 
-expandBoundingSphereRadius : Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> Convex -> Float -> Float
+expandBoundingSphereRadius : Frame3d Meters CenterOfMassCoordinates { defines : ShapeCoordinates } -> Convex -> Float -> Float
 expandBoundingSphereRadius frame3d { vertices } boundingSphereRadius =
     vertices
         |> List.foldl

--- a/src/Internal/Convex.elm
+++ b/src/Internal/Convex.elm
@@ -18,9 +18,9 @@ import Array exposing (Array)
 import Dict
 import Direction3d
 import Frame3d exposing (Frame3d)
-import Internal.Coordinates exposing (BodyLocalCoordinates, ShapeLocalCoordinates, WorldCoordinates)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
+import Physics.Coordinates exposing (BodyCoordinates, ShapeCoordinates, WorldCoordinates)
 import Point3d
 import Set
 
@@ -367,7 +367,7 @@ foldUniqueEdges fn acc { vertices, uniqueEdges } =
             acc
 
 
-expandBoundingSphereRadius : Frame3d Meters BodyLocalCoordinates { defines : ShapeLocalCoordinates } -> Convex -> Float -> Float
+expandBoundingSphereRadius : Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> Convex -> Float -> Float
 expandBoundingSphereRadius frame3d { vertices } boundingSphereRadius =
     vertices
         |> List.foldl
@@ -383,7 +383,7 @@ expandBoundingSphereRadius frame3d { vertices } boundingSphereRadius =
         |> sqrt
 
 
-raycast : { from : Vec3, direction : Vec3 } -> Frame3d Meters WorldCoordinates { defines : ShapeLocalCoordinates } -> Convex -> Maybe { distance : Float, point : Vec3, normal : Vec3 }
+raycast : { from : Vec3, direction : Vec3 } -> Frame3d Meters WorldCoordinates { defines : ShapeCoordinates } -> Convex -> Maybe { distance : Float, point : Vec3, normal : Vec3 }
 raycast { direction, from } frame3d convex =
     List.foldl
         (\face maybeHit ->

--- a/src/Internal/Convex.elm
+++ b/src/Internal/Convex.elm
@@ -18,9 +18,10 @@ import Array exposing (Array)
 import Dict
 import Direction3d
 import Frame3d exposing (Frame3d)
+import Internal.Coordinates exposing (CenterOfMassCoordinates)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
-import Physics.Coordinates exposing (CenterOfMassCoordinates, ShapeCoordinates, WorldCoordinates)
+import Physics.Coordinates exposing (ShapeCoordinates, WorldCoordinates)
 import Point3d
 import Set
 

--- a/src/Internal/Coordinates.elm
+++ b/src/Internal/Coordinates.elm
@@ -1,20 +1,9 @@
-module Internal.Coordinates exposing (BodyLocalCoordinates, ShapeLocalCoordinates, ShapeWorldFrame3d, WorldCoordinates)
+module Internal.Coordinates exposing (ShapeWorldFrame3d)
 
 import Frame3d exposing (Frame3d)
 import Length exposing (Meters)
-
-
-type WorldCoordinates
-    = WorldCoordinates
-
-
-type BodyLocalCoordinates
-    = BodyLocalCoordinates
-
-
-type ShapeLocalCoordinates
-    = ShapeLocalCoordinates
+import Physics.Coordinates exposing (ShapeCoordinates, WorldCoordinates)
 
 
 type alias ShapeWorldFrame3d =
-    Frame3d Meters WorldCoordinates { defines : ShapeLocalCoordinates }
+    Frame3d Meters WorldCoordinates { defines : ShapeCoordinates }

--- a/src/Internal/Coordinates.elm
+++ b/src/Internal/Coordinates.elm
@@ -1,4 +1,4 @@
-module Internal.Coordinates exposing (ShapeWorldFrame3d)
+module Internal.Coordinates exposing (CenterOfMassCoordinates, ShapeWorldFrame3d)
 
 import Frame3d exposing (Frame3d)
 import Length exposing (Meters)
@@ -7,3 +7,7 @@ import Physics.Coordinates exposing (ShapeCoordinates, WorldCoordinates)
 
 type alias ShapeWorldFrame3d =
     Frame3d Meters WorldCoordinates { defines : ShapeCoordinates }
+
+
+type CenterOfMassCoordinates
+    = CenterOfMassCoordinates

--- a/src/Internal/Equation.elm
+++ b/src/Internal/Equation.elm
@@ -11,12 +11,12 @@ import Frame3d
 import Internal.Body exposing (Body)
 import Internal.Constraint exposing (Constraint(..))
 import Internal.Contact exposing (Contact, ContactGroup)
+import Internal.Coordinates exposing (CenterOfMassCoordinates)
 import Internal.JacobianElement as JacobianElement exposing (JacobianElement)
 import Internal.Material as Material
 import Internal.Matrix3 as Mat3
 import Internal.SolverBody exposing (SolverBody)
 import Internal.Vector3 as Vec3 exposing (Vec3)
-import Physics.Coordinates exposing (CenterOfMassCoordinates)
 import Point3d
 import Vector3d
 

--- a/src/Internal/Equation.elm
+++ b/src/Internal/Equation.elm
@@ -16,6 +16,7 @@ import Internal.Material as Material
 import Internal.Matrix3 as Mat3
 import Internal.SolverBody exposing (SolverBody)
 import Internal.Vector3 as Vec3 exposing (Vec3)
+import Physics.Coordinates exposing (CenterOfMassCoordinates)
 import Point3d
 import Vector3d
 
@@ -69,7 +70,7 @@ type alias EquationsGroup =
     }
 
 
-constraintEquationsGroup : Float -> Body data -> Body data -> List Constraint -> EquationsGroup
+constraintEquationsGroup : Float -> Body data -> Body data -> List (Constraint CenterOfMassCoordinates) -> EquationsGroup
 constraintEquationsGroup dt body1 body2 constraints =
     { bodyId1 = body1.id
     , bodyId2 = body2.id
@@ -112,7 +113,7 @@ axes =
     [ Vec3.i, Vec3.j, Vec3.k ]
 
 
-addConstraintEquations : Float -> Body data -> Body data -> Constraint -> List SolverEquation -> List SolverEquation
+addConstraintEquations : Float -> Body data -> Body data -> Constraint CenterOfMassCoordinates -> List SolverEquation -> List SolverEquation
 addConstraintEquations dt body1 body2 constraint =
     case constraint of
         PointToPoint { pivot1, pivot2 } ->

--- a/src/Internal/Equation.elm
+++ b/src/Internal/Equation.elm
@@ -7,6 +7,8 @@ module Internal.Equation exposing
     , contactEquationsGroup
     )
 
+import Axis3d
+import Direction3d
 import Frame3d
 import Internal.Body exposing (Body)
 import Internal.Constraint exposing (Constraint(..))
@@ -17,6 +19,7 @@ import Internal.Material as Material
 import Internal.Matrix3 as Mat3
 import Internal.SolverBody exposing (SolverBody)
 import Internal.Vector3 as Vec3 exposing (Vec3)
+import Length
 import Point3d
 import Vector3d
 
@@ -116,15 +119,28 @@ axes =
 addConstraintEquations : Float -> Body data -> Body data -> Constraint CenterOfMassCoordinates -> List SolverEquation -> List SolverEquation
 addConstraintEquations dt body1 body2 constraint =
     case constraint of
-        PointToPoint { pivot1, pivot2 } ->
-            addPointToPointConstraintEquations dt body1 body2 pivot1 pivot2
+        PointToPoint pivot1 pivot2 ->
+            addPointToPointConstraintEquations dt body1 body2 (Point3d.toMeters pivot1) (Point3d.toMeters pivot2)
 
-        Hinge { pivot1, axis1, pivot2, axis2 } ->
+        Hinge axis1 axis2 ->
+            let
+                pivot1 =
+                    Point3d.toMeters (Axis3d.originPoint axis1)
+
+                dir1 =
+                    Direction3d.unwrap (Axis3d.direction axis1)
+
+                pivot2 =
+                    Point3d.toMeters (Axis3d.originPoint axis2)
+
+                dir2 =
+                    Direction3d.unwrap (Axis3d.direction axis2)
+            in
             addPointToPointConstraintEquations dt body1 body2 pivot1 pivot2
-                >> addRotationalConstraintEquations dt body1 body2 axis1 axis2
+                >> addRotationalConstraintEquations dt body1 body2 dir1 dir2
 
         Distance distance ->
-            addDistanceConstraintEquations dt body1 body2 distance
+            addDistanceConstraintEquations dt body1 body2 (Length.inMeters distance)
 
 
 addDistanceConstraintEquations : Float -> Body data -> Body data -> Float -> List SolverEquation -> List SolverEquation

--- a/src/Internal/NarrowPhase.elm
+++ b/src/Internal/NarrowPhase.elm
@@ -11,9 +11,8 @@ import Collision.SphereSphere
 import Frame3d
 import Internal.Body exposing (Body)
 import Internal.Contact as Contact exposing (Contact)
-import Internal.Coordinates exposing (ShapeWorldFrame3d)
+import Internal.Coordinates exposing (CenterOfMassCoordinates, ShapeWorldFrame3d)
 import Internal.Shape exposing (Kind(..), Shape)
-import Physics.Coordinates exposing (CenterOfMassCoordinates)
 
 
 getContacts : Body data -> Body data -> List Contact

--- a/src/Internal/NarrowPhase.elm
+++ b/src/Internal/NarrowPhase.elm
@@ -13,6 +13,7 @@ import Internal.Body exposing (Body)
 import Internal.Contact as Contact exposing (Contact)
 import Internal.Coordinates exposing (ShapeWorldFrame3d)
 import Internal.Shape exposing (Kind(..), Shape)
+import Physics.Coordinates exposing (CenterOfMassCoordinates)
 
 
 getContacts : Body data -> Body data -> List Contact
@@ -34,7 +35,7 @@ getContacts body1 body2 =
         body1.shapes
 
 
-addShapeContacts : ShapeWorldFrame3d -> Shape -> ShapeWorldFrame3d -> Shape -> List Contact -> List Contact
+addShapeContacts : ShapeWorldFrame3d -> Shape CenterOfMassCoordinates -> ShapeWorldFrame3d -> Shape CenterOfMassCoordinates -> List Contact -> List Contact
 addShapeContacts frame3d1 shape1 frame3d2 shape2 contacts =
     case shape1.kind of
         Convex convex1 ->

--- a/src/Internal/Shape.elm
+++ b/src/Internal/Shape.elm
@@ -11,9 +11,9 @@ import Frame3d exposing (Frame3d)
 import Internal.AABB as AABB
 import Internal.Const as Const
 import Internal.Convex as Convex exposing (Convex)
-import Internal.Coordinates exposing (BodyLocalCoordinates, ShapeLocalCoordinates, WorldCoordinates)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
+import Physics.Coordinates exposing (BodyCoordinates, ShapeCoordinates, WorldCoordinates)
 import Point3d
 
 
@@ -22,7 +22,7 @@ type Protected
 
 
 type alias Shape =
-    { frame3d : Frame3d Meters BodyLocalCoordinates { defines : ShapeLocalCoordinates }
+    { frame3d : Frame3d Meters BodyCoordinates { defines : ShapeCoordinates }
     , kind : Kind
     }
 
@@ -34,7 +34,7 @@ type Kind
     | Particle
 
 
-aabbClosure : Kind -> Frame3d Meters BodyLocalCoordinates { defines : ShapeLocalCoordinates } -> AABB.AABB
+aabbClosure : Kind -> Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> AABB.AABB
 aabbClosure kind =
     case kind of
         Convex convex ->
@@ -70,7 +70,7 @@ expandBoundingSphereRadius { frame3d, kind } boundingSphereRadius =
             max boundingSphereRadius (Vec3.length (Point3d.toMeters (Frame3d.originPoint frame3d)))
 
 
-raycast : { from : Vec3, direction : Vec3 } -> Frame3d Meters WorldCoordinates { defines : ShapeLocalCoordinates } -> Shape -> Maybe { distance : Float, point : Vec3, normal : Vec3 }
+raycast : { from : Vec3, direction : Vec3 } -> Frame3d Meters WorldCoordinates { defines : ShapeCoordinates } -> Shape -> Maybe { distance : Float, point : Vec3, normal : Vec3 }
 raycast ray frame3d { kind } =
     case kind of
         Plane ->

--- a/src/Internal/Shape.elm
+++ b/src/Internal/Shape.elm
@@ -11,9 +11,10 @@ import Frame3d exposing (Frame3d)
 import Internal.AABB as AABB
 import Internal.Const as Const
 import Internal.Convex as Convex exposing (Convex)
+import Internal.Coordinates exposing (CenterOfMassCoordinates)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
-import Physics.Coordinates exposing (BodyCoordinates, CenterOfMassCoordinates, ShapeCoordinates, WorldCoordinates)
+import Physics.Coordinates exposing (BodyCoordinates, ShapeCoordinates, WorldCoordinates)
 import Point3d
 
 

--- a/src/Internal/Shape.elm
+++ b/src/Internal/Shape.elm
@@ -13,16 +13,17 @@ import Internal.Const as Const
 import Internal.Convex as Convex exposing (Convex)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Length exposing (Meters)
-import Physics.Coordinates exposing (BodyCoordinates, ShapeCoordinates, WorldCoordinates)
+import Physics.Coordinates exposing (BodyCoordinates, CenterOfMassCoordinates, ShapeCoordinates, WorldCoordinates)
 import Point3d
 
 
 type Protected
-    = Protected Shape
+    = Protected (Shape BodyCoordinates)
 
 
-type alias Shape =
-    { frame3d : Frame3d Meters BodyCoordinates { defines : ShapeCoordinates }
+type alias Shape coordinates =
+    { frame3d : Frame3d Meters coordinates { defines : ShapeCoordinates }
+    , volume : Float
     , kind : Kind
     }
 
@@ -34,7 +35,7 @@ type Kind
     | Particle
 
 
-aabbClosure : Kind -> Frame3d Meters BodyCoordinates { defines : ShapeCoordinates } -> AABB.AABB
+aabbClosure : Kind -> Frame3d Meters CenterOfMassCoordinates { defines : ShapeCoordinates } -> AABB.AABB
 aabbClosure kind =
     case kind of
         Convex convex ->
@@ -50,7 +51,7 @@ aabbClosure kind =
             AABB.particle
 
 
-expandBoundingSphereRadius : Shape -> Float -> Float
+expandBoundingSphereRadius : Shape CenterOfMassCoordinates -> Float -> Float
 expandBoundingSphereRadius { frame3d, kind } boundingSphereRadius =
     case kind of
         Convex convex ->
@@ -70,7 +71,7 @@ expandBoundingSphereRadius { frame3d, kind } boundingSphereRadius =
             max boundingSphereRadius (Vec3.length (Point3d.toMeters (Frame3d.originPoint frame3d)))
 
 
-raycast : { from : Vec3, direction : Vec3 } -> Frame3d Meters WorldCoordinates { defines : ShapeCoordinates } -> Shape -> Maybe { distance : Float, point : Vec3, normal : Vec3 }
+raycast : { from : Vec3, direction : Vec3 } -> Frame3d Meters WorldCoordinates { defines : ShapeCoordinates } -> Shape CenterOfMassCoordinates -> Maybe { distance : Float, point : Vec3, normal : Vec3 }
 raycast ray frame3d { kind } =
     case kind of
         Plane ->

--- a/src/Physics/Body.elm
+++ b/src/Physics/Body.elm
@@ -28,7 +28,7 @@ module Physics.Body exposing
 
 ## Advanced
 
-@docs setMaterial, compound, centerOfMass
+@docs setMaterial, compound
 
 -}
 

--- a/src/Physics/Body.elm
+++ b/src/Physics/Body.elm
@@ -41,7 +41,7 @@ import Mass exposing (Mass)
 import Physics.Coordinates exposing (BodyCoordinates, ShapeCoordinates, WorldCoordinates)
 import Physics.Material exposing (Material)
 import Physics.Shape as Shape exposing (Shape)
-import Point3d exposing (Point3d)
+import Point3d
 
 
 {-| Represents a physical body containing
@@ -208,7 +208,7 @@ setFrame3d userFrame3d (Protected body) =
 -}
 getFrame3d : Body data -> Frame3d Meters WorldCoordinates { defines : BodyCoordinates }
 getFrame3d (Protected { frame3d, centerOfMassFrame3d }) =
-    Frame3d.placeIn frame3d (Frame3d.relativeTo centerOfMassFrame3d (Frame3d.atPoint Point3d.origin))
+    Frame3d.placeIn frame3d (Frame3d.relativeTo centerOfMassFrame3d Frame3d.atOrigin)
 
 
 {-| Set user-defined data.

--- a/src/Physics/Body.elm
+++ b/src/Physics/Body.elm
@@ -49,7 +49,7 @@ user defined data, like a WebGL mesh.
 
 By default a body is positioned in the center
 of the world and doesn’t move. To change this,
-use [setFrame3d](#setFrame3d) or [setBehavior](#setBehavior).
+use [setFrame3d](#setFrame3d) and [setBehavior](#setBehavior).
 
 The supported bodies are:
 
@@ -132,7 +132,8 @@ type Behavior
     | Static
 
 
-{-| Dynamic bodies move and react to forces and collide with other dynamic and static bodies.
+{-| Dynamic bodies move and react to forces and collide with
+other dynamic and static bodies.
 -}
 dynamic : Mass -> Behavior
 dynamic kilos =
@@ -184,12 +185,12 @@ setBehavior behavior (Protected body) =
 
 
 {-| Set the position and orientation of the body in the world,
-e.g. to position a body 5 meters below the origin:
+e.g. to raise a body 5 meters above the origin:
 
     movedBody =
         body
             |> setFrame3d
-                (Frame3d.atPoint (Point3d.meters 0 0 -5))
+                (Frame3d.atPoint (Point3d.meters 0 0 5))
 
 For all possible ways to construct and modify `Frame3d`, check
 [elm-geometry package docs](https://package.elm-lang.org/packages/ianmackenzie/elm-geometry/2.0.0/Frame3d).

--- a/src/Physics/Constraint.elm
+++ b/src/Physics/Constraint.elm
@@ -12,7 +12,6 @@ module Physics.Constraint exposing
 -}
 
 import Axis3d exposing (Axis3d)
-import Direction3d
 import Internal.Constraint as Internal
 import Length exposing (Length, Meters)
 import Physics.Coordinates exposing (BodyCoordinates)
@@ -33,11 +32,8 @@ pointToPoint :
     Point3d Meters BodyCoordinates
     -> Point3d Meters BodyCoordinates
     -> Constraint
-pointToPoint pivot1 pivot2 =
+pointToPoint =
     Internal.PointToPoint
-        { pivot1 = Point3d.toMeters pivot1
-        , pivot2 = Point3d.toMeters pivot2
-        }
 
 
 {-| Keep two bodies connected with each other and limit the freedom of rotation.
@@ -47,18 +43,13 @@ hinge :
     Axis3d Meters BodyCoordinates
     -> Axis3d Meters BodyCoordinates
     -> Constraint
-hinge axis1 axis2 =
+hinge =
     Internal.Hinge
-        { pivot1 = Point3d.toMeters (Axis3d.originPoint axis1)
-        , axis1 = Direction3d.unwrap (Axis3d.direction axis1)
-        , pivot2 = Point3d.toMeters (Axis3d.originPoint axis2)
-        , axis2 = Direction3d.unwrap (Axis3d.direction axis2)
-        }
 
 
 {-| Keep the centers of two bodies at the constant distance
 from each other.
 -}
 distance : Length -> Constraint
-distance length =
-    Internal.Distance (Length.inMeters length)
+distance =
+    Internal.Distance

--- a/src/Physics/Constraint.elm
+++ b/src/Physics/Constraint.elm
@@ -22,7 +22,7 @@ import Point3d exposing (Point3d)
 of two bodies with relation to each other.
 -}
 type alias Constraint =
-    Internal.Constraint BodyCoordinates
+    Internal.Protected
 
 
 {-| Connect a point on the first body with a point on the second body.
@@ -32,8 +32,8 @@ pointToPoint :
     Point3d Meters BodyCoordinates
     -> Point3d Meters BodyCoordinates
     -> Constraint
-pointToPoint =
-    Internal.PointToPoint
+pointToPoint pivot1 pivot2 =
+    Internal.Protected (Internal.PointToPoint pivot1 pivot2)
 
 
 {-| Keep two bodies connected with each other and limit the freedom of rotation.
@@ -43,13 +43,13 @@ hinge :
     Axis3d Meters BodyCoordinates
     -> Axis3d Meters BodyCoordinates
     -> Constraint
-hinge =
-    Internal.Hinge
+hinge axis1 axis2 =
+    Internal.Protected (Internal.Hinge axis1 axis2)
 
 
 {-| Keep the centers of two bodies at the constant distance
 from each other.
 -}
 distance : Length -> Constraint
-distance =
-    Internal.Distance
+distance length =
+    Internal.Protected (Internal.Distance length)

--- a/src/Physics/Constraint.elm
+++ b/src/Physics/Constraint.elm
@@ -14,8 +14,8 @@ module Physics.Constraint exposing
 import Axis3d exposing (Axis3d)
 import Direction3d
 import Internal.Constraint as Internal
-import Internal.Coordinates exposing (BodyLocalCoordinates)
 import Length exposing (Length, Meters)
+import Physics.Coordinates exposing (BodyCoordinates)
 import Point3d exposing (Point3d)
 
 
@@ -30,8 +30,8 @@ type alias Constraint =
 Points are defined within the bodies’ local coordinate systems.
 -}
 pointToPoint :
-    Point3d Meters BodyLocalCoordinates
-    -> Point3d Meters BodyLocalCoordinates
+    Point3d Meters BodyCoordinates
+    -> Point3d Meters BodyCoordinates
     -> Constraint
 pointToPoint pivot1 pivot2 =
     Internal.PointToPoint
@@ -44,8 +44,8 @@ pointToPoint pivot1 pivot2 =
 Useful for e.g. connecting a window to a window frame.
 -}
 hinge :
-    Axis3d Meters BodyLocalCoordinates
-    -> Axis3d Meters BodyLocalCoordinates
+    Axis3d Meters BodyCoordinates
+    -> Axis3d Meters BodyCoordinates
     -> Constraint
 hinge axis1 axis2 =
     Internal.Hinge

--- a/src/Physics/Constraint.elm
+++ b/src/Physics/Constraint.elm
@@ -23,7 +23,7 @@ import Point3d exposing (Point3d)
 of two bodies with relation to each other.
 -}
 type alias Constraint =
-    Internal.Constraint
+    Internal.Constraint BodyCoordinates
 
 
 {-| Connect a point on the first body with a point on the second body.

--- a/src/Physics/Constraint.elm
+++ b/src/Physics/Constraint.elm
@@ -37,7 +37,7 @@ pointToPoint pivot1 pivot2 =
 
 
 {-| Keep two bodies connected with each other and limit the freedom of rotation.
-Useful for e.g. connecting a window to a window frame.
+Useful for e.g. connecting a window to a window frame, or to connect a wheel to a car.
 -}
 hinge :
     Axis3d Meters BodyCoordinates

--- a/src/Physics/Coordinates.elm
+++ b/src/Physics/Coordinates.elm
@@ -1,15 +1,22 @@
-module Physics.Coordinates exposing (BodyLocalCoordinates, ShapeLocalCoordinates, WorldCoordinates)
+module Physics.Coordinates exposing (WorldCoordinates, BodyCoordinates, ShapeCoordinates)
 
-import Internal.Coordinates as Coordinates
+{-| These type parameters indicate coordinate systems.
 
+@docs WorldCoordinates, BodyCoordinates, ShapeCoordinates
 
-type alias WorldCoordinates =
-    Coordinates.WorldCoordinates
-
-
-type alias BodyLocalCoordinates =
-    Coordinates.BodyLocalCoordinates
+-}
 
 
-type alias ShapeLocalCoordinates =
-    Coordinates.ShapeLocalCoordinates
+{-| -}
+type WorldCoordinates
+    = WorldCoordinates
+
+
+{-| -}
+type BodyCoordinates
+    = BodyCoordinates
+
+
+{-| -}
+type ShapeCoordinates
+    = ShapeCoordinates

--- a/src/Physics/Coordinates.elm
+++ b/src/Physics/Coordinates.elm
@@ -2,7 +2,7 @@ module Physics.Coordinates exposing (WorldCoordinates, BodyCoordinates, ShapeCoo
 
 {-| These type parameters indicate coordinate systems.
 
-@docs WorldCoordinates, BodyCoordinates, ShapeCoordinates, BodyCenterOfMassCoordinates
+@docs WorldCoordinates, BodyCoordinates, ShapeCoordinates
 
 -}
 

--- a/src/Physics/Coordinates.elm
+++ b/src/Physics/Coordinates.elm
@@ -1,8 +1,11 @@
-module Physics.Coordinates exposing (WorldCoordinates, BodyCoordinates, ShapeCoordinates)
+module Physics.Coordinates exposing
+    ( WorldCoordinates, BodyCoordinates, ShapeCoordinates
+    , CenterOfMassCoordinates
+    )
 
 {-| These type parameters indicate coordinate systems.
 
-@docs WorldCoordinates, BodyCoordinates, ShapeCoordinates
+@docs WorldCoordinates, BodyCoordinates, ShapeCoordinates, BodyCenterOfMassCoordinates
 
 -}
 
@@ -20,3 +23,8 @@ type BodyCoordinates
 {-| -}
 type ShapeCoordinates
     = ShapeCoordinates
+
+
+{-| -}
+type CenterOfMassCoordinates
+    = CenterOfMassCoordinates

--- a/src/Physics/Coordinates.elm
+++ b/src/Physics/Coordinates.elm
@@ -1,7 +1,4 @@
-module Physics.Coordinates exposing
-    ( WorldCoordinates, BodyCoordinates, ShapeCoordinates
-    , CenterOfMassCoordinates
-    )
+module Physics.Coordinates exposing (WorldCoordinates, BodyCoordinates, ShapeCoordinates)
 
 {-| These type parameters indicate coordinate systems.
 
@@ -23,8 +20,3 @@ type BodyCoordinates
 {-| -}
 type ShapeCoordinates
     = ShapeCoordinates
-
-
-{-| -}
-type CenterOfMassCoordinates
-    = CenterOfMassCoordinates

--- a/src/Physics/Debug.elm
+++ b/src/Physics/Debug.elm
@@ -19,11 +19,12 @@ import Frame3d exposing (Frame3d)
 import Internal.Body as InternalBody
 import Internal.BroadPhase as BroadPhase
 import Internal.Convex as Convex
+import Internal.Coordinates exposing (CenterOfMassCoordinates)
 import Internal.Shape exposing (Kind(..), Shape)
 import Internal.World exposing (Protected(..))
 import Length exposing (Meters)
 import Physics.Body exposing (Body)
-import Physics.Coordinates exposing (BodyCoordinates, CenterOfMassCoordinates, WorldCoordinates)
+import Physics.Coordinates exposing (BodyCoordinates, WorldCoordinates)
 import Physics.World exposing (World)
 import Point3d exposing (Point3d)
 

--- a/src/Physics/Debug.elm
+++ b/src/Physics/Debug.elm
@@ -44,7 +44,7 @@ getContacts (Protected world) =
         (BroadPhase.getContacts world)
 
 
-{-| Get the center of mass of a body
+{-| Get the center of mass of the body.
 -}
 getCenterOfMass : Body data -> Point3d Meters BodyCoordinates
 getCenterOfMass (InternalBody.Protected { centerOfMassFrame3d }) =

--- a/src/Physics/Debug.elm
+++ b/src/Physics/Debug.elm
@@ -18,23 +18,23 @@ import Direction3d exposing (Direction3d)
 import Internal.Body as InternalBody
 import Internal.BroadPhase as BroadPhase
 import Internal.Convex as Convex
-import Internal.Coordinates exposing (BodyLocalCoordinates)
 import Internal.Shape exposing (Kind(..), Shape)
 import Internal.World exposing (Protected(..))
 import Length exposing (Meters)
 import Physics.Body exposing (Body)
+import Physics.Coordinates exposing (BodyCoordinates, WorldCoordinates)
 import Physics.World exposing (World)
 import Point3d exposing (Point3d)
 
 
 {-| Get the contact points in the world.
 -}
-getContacts : World data -> List { x : Float, y : Float, z : Float }
+getContacts : World data -> List (Point3d Meters WorldCoordinates)
 getContacts (Protected world) =
     List.foldl
         (\{ contacts } acc1 ->
             List.foldl
-                (\{ pi, pj } acc2 -> pi :: pj :: acc2)
+                (\{ pi, pj } acc2 -> Point3d.fromMeters pi :: Point3d.fromMeters pj :: acc2)
                 acc1
                 contacts
         )
@@ -49,8 +49,8 @@ These are both expressed within the local body coordinate system.
 
 -}
 type alias FaceNormal =
-    { normal : Direction3d BodyLocalCoordinates
-    , point : Point3d Meters BodyLocalCoordinates
+    { normal : Direction3d BodyCoordinates
+    , point : Point3d Meters BodyCoordinates
     }
 
 
@@ -88,8 +88,8 @@ These are both expressed within the local body coordinate system.
 
 -}
 type alias UniqueEdge =
-    { direction : Direction3d BodyLocalCoordinates
-    , point : Point3d Meters BodyLocalCoordinates
+    { direction : Direction3d BodyCoordinates
+    , point : Point3d Meters BodyCoordinates
     }
 
 

--- a/src/Physics/Debug.elm
+++ b/src/Physics/Debug.elm
@@ -4,7 +4,8 @@ module Physics.Debug exposing
     , UniqueEdge, getUniqueEdges
     )
 
-{-| A list of utilities that may be useful for debugging.
+{-| A list of utilities that may be useful for
+debugging issues with elm-physics itself.
 
 @docs getContacts, getCenterOfMass
 

--- a/src/Physics/Shape.elm
+++ b/src/Physics/Shape.elm
@@ -1,11 +1,11 @@
 module Physics.Shape exposing
-    ( Shape, block, sphere, particle
+    ( Shape, block, sphere
     , setFrame3d
     )
 
 {-|
 
-@docs Shape, block, sphere, particle
+@docs Shape, block, sphere
 
 
 ## Positioning and Orientation
@@ -30,11 +30,10 @@ import Point3d
 If you need a body with a single shape, use the corresponding functions
 from the [Physics.Body](Physics-Body) module.
 
-The supported shapes are:
+The only supported shapes are:
 
   - [block](#block),
-  - [sphere](#sphere),
-  - [particle](#particle).
+  - [sphere](#sphere).
 
 -}
 type alias Shape =
@@ -58,17 +57,7 @@ block x y z =
     Protected
         { frame3d = defaultFrame
         , kind = Internal.Convex (Convex.fromBlock halfX halfY halfZ)
-        }
-
-
-{-| A plane with the normal that points in the
-direction of the z axis.
--}
-plane : Shape
-plane =
-    Protected
-        { frame3d = defaultFrame
-        , kind = Internal.Plane
+        , volume = Length.inMeters x * Length.inMeters y * Length.inMeters z
         }
 
 
@@ -79,15 +68,7 @@ sphere radius =
     Protected
         { frame3d = defaultFrame
         , kind = Internal.Sphere (Length.inMeters radius)
-        }
-
-
-{-| -}
-particle : Shape
-particle =
-    Protected
-        { frame3d = defaultFrame
-        , kind = Internal.Particle
+        , volume = 4 / 3 * pi * (Length.inMeters radius ^ 3)
         }
 
 

--- a/src/Physics/Shape.elm
+++ b/src/Physics/Shape.elm
@@ -10,8 +10,9 @@ module Physics.Shape exposing
 
 ## Positioning and Orientation
 
-Shapes are positioned in the local body coordinate system,
-they can be moved and rotated just like bodies in the world using frame3d.
+Shapes are positioned in the body coordinate system,
+they can be moved and rotated just like bodies in
+the world using `Frame3d`.
 
 @docs setFrame3d
 

--- a/src/Physics/Shape.elm
+++ b/src/Physics/Shape.elm
@@ -1,11 +1,11 @@
 module Physics.Shape exposing
-    ( Shape, block, plane, sphere, particle
+    ( Shape, block, sphere, particle
     , setFrame3d
     )
 
 {-|
 
-@docs Shape, block, plane, sphere, particle
+@docs Shape, block, sphere, particle
 
 
 ## Positioning and Orientation
@@ -19,9 +19,9 @@ they can be moved and rotated just like bodies in the world using frame3d.
 
 import Frame3d exposing (Frame3d)
 import Internal.Convex as Convex
-import Internal.Coordinates exposing (BodyLocalCoordinates, ShapeLocalCoordinates)
 import Internal.Shape as Internal exposing (Protected(..))
 import Length exposing (Length, Meters)
+import Physics.Coordinates exposing (BodyCoordinates, ShapeCoordinates)
 import Point3d
 
 
@@ -33,8 +33,8 @@ from the [Physics.Body](Physics-Body) module.
 The supported shapes are:
 
   - [block](#block),
-  - [plane](#plane),
-  - [sphere](#sphere).
+  - [sphere](#sphere),
+  - [particle](#particle).
 
 -}
 type alias Shape =
@@ -91,18 +91,17 @@ particle =
         }
 
 
-defaultFrame : Frame3d Meters BodyLocalCoordinates { defines : ShapeLocalCoordinates }
+defaultFrame : Frame3d Meters BodyCoordinates { defines : ShapeCoordinates }
 defaultFrame =
     Frame3d.atPoint Point3d.origin
 
 
-{-| Move the shape in a body by a vector offset from
-the current local position.
+{-| Change the position and orientation of the shape in the body.
 -}
 setFrame3d :
-    Frame3d Meters BodyLocalCoordinates { defines : ShapeLocalCoordinates }
+    Frame3d Meters BodyCoordinates { defines : ShapeCoordinates }
     -> Shape
-    -> Shape -- Vector3d Meters BodyCoordinates
+    -> Shape
 setFrame3d frame3d (Protected shape) =
     Protected
         { shape | frame3d = frame3d }

--- a/src/Physics/World.elm
+++ b/src/Physics/World.elm
@@ -130,7 +130,8 @@ getBodies (Protected { bodies }) =
 
 
 {-| Find the closest intersection of a ray against
-all the bodies in the world.
+all the bodies in the world. Except for particles,
+because they have no size.
 -}
 raycast :
     Point3d Meters WorldCoordinates

--- a/src/Physics/World.elm
+++ b/src/Physics/World.elm
@@ -231,7 +231,10 @@ to use `constrainIf` to apply constraints on a subset of bodies.
         constrainIf (always True)
 
 -}
-constrain : (Body data -> Body data -> List Constraint) -> World data -> World data
+constrain :
+    (Body data -> Body data -> List Constraint)
+    -> World data
+    -> World data
 constrain =
     constrainIf (always True)
 
@@ -248,7 +251,11 @@ and preselect parts of a single car with:
             )
 
 -}
-constrainIf : (Body data -> Bool) -> (Body data -> Body data -> List Constraint) -> World data -> World data
+constrainIf :
+    (Body data -> Bool)
+    -> (Body data -> Body data -> List Constraint)
+    -> World data
+    -> World data
 constrainIf test fn (Protected world) =
     let
         -- Filter the bodies for permutations

--- a/src/Physics/World.elm
+++ b/src/Physics/World.elm
@@ -20,9 +20,10 @@ module Physics.World exposing
 import Acceleration exposing (Acceleration)
 import Direction3d exposing (Direction3d)
 import Duration exposing (Duration)
+import Frame3d
 import Internal.Body as InternalBody
 import Internal.BroadPhase as BroadPhase
-import Internal.Constraint exposing (ConstraintGroup)
+import Internal.Constraint as InternalConstraint exposing (ConstraintGroup)
 import Internal.Solver as Solver
 import Internal.Vector3 as Vec3
 import Internal.World as Internal exposing (Protected(..))
@@ -141,8 +142,8 @@ raycast from direction (Protected world) =
         Just { body, point, normal } ->
             Just
                 { body = InternalBody.Protected body
-                , point = Point3d.relativeTo body.frame3d (Point3d.fromMeters point)
-                , normal = Direction3d.relativeTo body.frame3d (Direction3d.unsafe normal)
+                , point = Point3d.relativeTo (Frame3d.placeIn body.frame3d (Frame3d.relativeTo body.centerOfMassFrame3d (Frame3d.atPoint Point3d.origin))) (Point3d.fromMeters point)
+                , normal = Direction3d.relativeTo (Frame3d.placeIn body.frame3d (Frame3d.relativeTo body.centerOfMassFrame3d (Frame3d.atPoint Point3d.origin))) (Direction3d.unsafe normal)
                 }
 
         _ ->
@@ -272,7 +273,7 @@ constrainIf test fn (Protected world) =
                 constraints ->
                     { bodyId1 = body1.id
                     , bodyId2 = body2.id
-                    , constraints = constraints
+                    , constraints = List.map (InternalConstraint.relativeToCenterOfMass body1.centerOfMassFrame3d body2.centerOfMassFrame3d) constraints
                     }
                         :: constraintGroup
 

--- a/src/Physics/World.elm
+++ b/src/Physics/World.elm
@@ -1,5 +1,5 @@
 module Physics.World exposing
-    ( World, empty, add, setGravity
+    ( World, empty, setGravity, add
     , simulate, getBodies, raycast, RaycastResult
     , keepIf, update
     , constrain, constrainIf
@@ -7,7 +7,7 @@ module Physics.World exposing
 
 {-|
 
-@docs World, empty, add, setGravity
+@docs World, empty, setGravity, add
 
 @docs simulate, getBodies, raycast, RaycastResult
 
@@ -17,17 +17,19 @@ module Physics.World exposing
 
 -}
 
+import Acceleration exposing (Acceleration)
 import Direction3d exposing (Direction3d)
+import Duration exposing (Duration)
 import Internal.Body as InternalBody
 import Internal.BroadPhase as BroadPhase
 import Internal.Constraint exposing (ConstraintGroup)
-import Internal.Coordinates exposing (BodyLocalCoordinates, WorldCoordinates)
 import Internal.Solver as Solver
 import Internal.Vector3 as Vec3
 import Internal.World as Internal exposing (Protected(..))
 import Length exposing (Meters)
 import Physics.Body exposing (Body)
 import Physics.Constraint exposing (Constraint)
+import Physics.Coordinates exposing (BodyCoordinates, WorldCoordinates)
 import Point3d exposing (Point3d)
 
 
@@ -50,7 +52,31 @@ empty =
         }
 
 
-{-| Adds a body to the world.
+{-| Set the [standard gravity](https://en.wikipedia.org/wiki/Standard_gravity) and its direction, e.g.:
+
+    planetEarth =
+        setGravity
+            (Acceleration.metersPerSecondSquared 9.80665)
+            Direction3d.negativeZ
+            world
+
+-}
+setGravity :
+    Acceleration
+    -> Direction3d WorldCoordinates
+    -> World data
+    -> World data
+setGravity acceleration direction (Protected world) =
+    Protected
+        { world
+            | gravity =
+                Vec3.scale
+                    (Acceleration.inMetersPerSecondSquared acceleration)
+                    (Direction3d.unwrap direction)
+        }
+
+
+{-| Add a body to the world.
 
     worldWithFloor =
         add planeBody world
@@ -78,33 +104,16 @@ add (InternalBody.Protected body) (Protected world) =
                 }
 
 
-{-| Set the [standard gravity](https://en.wikipedia.org/wiki/Standard_gravity), e.g.:
-
-    planetEarth =
-        setGravity { x = 0, y = 0, z = -9.80665 } world
-
--}
-setGravity :
-    { x : Float, y : Float, z : Float }
-    -> World data
-    -> World data -- Vector3d Acceletation WorldCoordinates // decouple direction and magnitude?
-setGravity gravity (Protected world) =
-    Protected { world | gravity = gravity }
-
-
-{-| Simulate the world, given the number of milliseconds since the last frame.
+{-| Simulate the world, given the number of seconds since the last frame.
 
 Call this function on a message from the [onAnimationFrame](https://package.elm-lang.org/packages/elm/browser/latest/Browser-Events#onAnimationFrame) subscription.
 
 -}
-simulate :
-    Float
-    -> World data
-    -> World data -- Duration
+simulate : Duration -> World data -> World data
 simulate dt (Protected world) =
     world
         |> Internal.addGravityForces
-        |> Solver.solve (dt / 1000) (BroadPhase.getContacts world)
+        |> Solver.solve (Duration.inSeconds dt) (BroadPhase.getContacts world)
         |> Protected
 
 
@@ -146,8 +155,8 @@ expressed within the local body coordinate system.
 -}
 type alias RaycastResult data =
     { body : Body data
-    , point : Point3d Meters BodyLocalCoordinates
-    , normal : Direction3d BodyLocalCoordinates
+    , point : Point3d Meters BodyCoordinates
+    , normal : Direction3d BodyCoordinates
     }
 
 
@@ -191,7 +200,11 @@ Check the [Physics.Constraint](Physics-Constraint) module for possible constrain
     worldWithACar =
         constrain
             (\b1 b2 ->
-                case ( (Body.getData b1).part, (Body.getData b2).part ) of
+                case
+                    ( (Body.getData b1).part
+                    , (Body.getData b2).part
+                    )
+                of
                     ( "wheel1", "base" ) ->
                         [ hingeConstraint1 ]
 
@@ -228,7 +241,10 @@ For the above example we can tag each part of a car with the `carId`,
 and preselect parts of a single car with:
 
     constrainCar carId =
-        constrainIf (\body -> (Body.getData body).carId == carId)
+        constrainIf
+            (\body ->
+                (Body.getData body).carId == carId
+            )
 
 -}
 constrainIf : (Body data -> Bool) -> (Body data -> Body data -> List Constraint) -> World data -> World data

--- a/tests/BodyTest.elm
+++ b/tests/BodyTest.elm
@@ -7,6 +7,7 @@ import Internal.Const as Const
 import Internal.Convex as Convex
 import Internal.Shape as Shape exposing (Shape)
 import Internal.Vector3 as Vec3
+import Physics.Coordinates exposing (BodyCoordinates)
 import Point3d
 import Test exposing (Test, describe, test)
 
@@ -35,15 +36,17 @@ boundingSphereRadius =
         ]
 
 
-box : Float -> Float -> Float -> Shape
+box : Float -> Float -> Float -> Shape BodyCoordinates
 box x y z =
     { frame3d = Frame3d.atPoint Point3d.origin
+    , volume = x * y * z
     , kind = Shape.Convex (Convex.fromBlock x y z)
     }
 
 
-plane : Shape
+plane : Shape BodyCoordinates
 plane =
     { frame3d = Frame3d.atPoint Point3d.origin
+    , volume = 0
     , kind = Shape.Plane
     }

--- a/tests/ConvexConvexTest.elm
+++ b/tests/ConvexConvexTest.elm
@@ -29,12 +29,12 @@ getContacts =
                         -- going slightly into another box
                         Frame3d.atPoint Point3d.origin
                             |> Frame3d.rotateAround Axis3d.y (Angle.radians (pi / 2))
-                            |> Frame3d.moveTo (Point3d.fromMeters { x = 0, y = 0, z = 2.1 })
+                            |> Frame3d.moveTo (Point3d.meters 0 0 2.1)
 
                     t2 =
                         Frame3d.atPoint Point3d.origin
                             |> Frame3d.rotateAround Axis3d.y (Angle.radians (pi / 2))
-                            |> Frame3d.moveTo (Point3d.fromMeters { x = 0, y = 0, z = 4 })
+                            |> Frame3d.moveTo (Point3d.meters 0 0 4)
                 in
                 Collision.ConvexConvex.addContacts t1 convex t2 convex []
                     |> List.length
@@ -51,12 +51,12 @@ getContacts =
                     frame3d1 =
                         Frame3d.atPoint Point3d.origin
                             |> Frame3d.rotateAround Axis3d.z (Angle.radians (pi / 2))
-                            |> Frame3d.moveTo (Point3d.fromMeters { x = -0.5, y = 0, z = 0 })
+                            |> Frame3d.moveTo (Point3d.meters  -0.5  0  0 )
 
                     frame3d2 =
                         Frame3d.atPoint Point3d.origin
                             |> Frame3d.rotateAround Axis3d.z (Angle.radians (pi / 4))
-                            |> Frame3d.moveTo (Point3d.fromMeters { x = 0.5, y = 0, z = 0 })
+                            |> Frame3d.moveTo (Point3d.meters  0.5  0 0 )
                 in
                 Collision.ConvexConvex.addContacts frame3d1 convex1 frame3d2 convex2 []
                     |> List.length
@@ -71,9 +71,9 @@ testSeparatingAxis =
             \_ ->
                 Expect.equal
                     (Collision.ConvexConvex.testSeparatingAxis
-                        { frame3d1 = Frame3d.atPoint (Point3d.fromMeters { x = -0.2, y = 0, z = 0 })
+                        { frame3d1 = Frame3d.atPoint (Point3d.meters  -0.2  0  0 )
                         , convex1 = Convex.fromBlock 0.5 0.5 0.5
-                        , frame3d2 = Frame3d.atPoint (Point3d.fromMeters { x = 0.2, y = 0, z = 0 })
+                        , frame3d2 = Frame3d.atPoint (Point3d.meters   0.2 0  0 )
                         , convex2 = Convex.fromBlock 0.5 0.5 0.5
                         }
                         Vec3.i
@@ -83,9 +83,9 @@ testSeparatingAxis =
             \_ ->
                 Expect.equal
                     (Collision.ConvexConvex.testSeparatingAxis
-                        { frame3d1 = Frame3d.atPoint (Point3d.fromMeters { x = -5.2, y = 0, z = 0 })
+                        { frame3d1 = Frame3d.atPoint (Point3d.meters  -5.2  0  0 )
                         , convex1 = Convex.fromBlock 0.5 0.5 0.5
-                        , frame3d2 = Frame3d.atPoint (Point3d.fromMeters { x = 0.2, y = 0, z = 0 })
+                        , frame3d2 = Frame3d.atPoint (Point3d.meters   0.2  0 0 )
                         , convex2 = Convex.fromBlock 0.5 0.5 0.5
                         }
                         Vec3.i
@@ -95,12 +95,12 @@ testSeparatingAxis =
             \_ ->
                 case
                     Collision.ConvexConvex.testSeparatingAxis
-                        { frame3d1 = Frame3d.atPoint (Point3d.fromMeters { x = 1, y = 0, z = 0 })
+                        { frame3d1 = Frame3d.atPoint (Point3d.meters  1  0  0 )
                         , convex1 = Convex.fromBlock 0.5 0.5 0.5
                         , frame3d2 =
                             Frame3d.atPoint Point3d.origin
                                 |> Frame3d.rotateAround Axis3d.z (Angle.radians (pi / 4))
-                                |> Frame3d.moveTo (Point3d.fromMeters { x = 0.2, y = 0, z = 0 })
+                                |> Frame3d.moveTo (Point3d.meters   0.2  0  0 )
                         , convex2 = Convex.fromBlock 0.5 0.5 0.5
                         }
                         Vec3.i
@@ -120,9 +120,9 @@ findSeparatingAxis =
             \_ ->
                 Expect.equal
                     (Collision.ConvexConvex.findSeparatingAxis
-                        (Frame3d.atPoint (Point3d.fromMeters { x = -0.2, y = 0, z = 0 }))
+                        (Frame3d.atPoint (Point3d.meters  -0.2  0  0 ))
                         (Convex.fromBlock 0.5 0.5 0.5)
-                        (Frame3d.atPoint (Point3d.fromMeters { x = 0.2, y = 0, z = 0 }))
+                        (Frame3d.atPoint (Point3d.meters  0.2  0  0 ))
                         (Convex.fromBlock 0.5 0.5 0.5)
                     )
                     (Just { x = -1, y = 0, z = 0 })
@@ -130,11 +130,11 @@ findSeparatingAxis =
             \_ ->
                 Expect.equal
                     (Collision.ConvexConvex.findSeparatingAxis
-                        (Frame3d.atPoint (Point3d.fromMeters { x = -0.2, y = 0, z = 0 }))
+                        (Frame3d.atPoint (Point3d.meters  -0.2  0  0 ))
                         (Convex.fromBlock 0.5 0.5 0.5)
                         (Frame3d.atPoint Point3d.origin
                             |> Frame3d.rotateAround Axis3d.z (Angle.radians (pi / 4))
-                            |> Frame3d.moveTo (Point3d.fromMeters { x = 0.2, y = 0, z = 0 })
+                            |> Frame3d.moveTo (Point3d.meters   0.2 0  0 )
                         )
                         (Convex.fromBlock 0.5 0.5 0.5)
                     )
@@ -176,7 +176,7 @@ project =
             \_ ->
                 Expect.equal
                     (Collision.ConvexConvex.project
-                        (Frame3d.atPoint (Point3d.fromMeters { x = 0, y = 1, z = 0 }))
+                        (Frame3d.atPoint (Point3d.meters  0  1  0 ))
                         (Convex.fromBlock 0.5 0.5 0.5).vertices
                         Vec3.j
                     )
@@ -186,7 +186,7 @@ project =
                 Collision.ConvexConvex.project
                     (Frame3d.atPoint Point3d.origin
                         |> Frame3d.rotateAround Axis3d.x (Angle.radians (pi / 2))
-                        |> Frame3d.moveTo (Point3d.fromMeters { x = 0, y = 1, z = 0 })
+                        |> Frame3d.moveTo (Point3d.meters   0  1  0 )
                     )
                     (Convex.fromBlock 0.5 0.5 0.5).vertices
                     Vec3.j

--- a/tests/SphereConvexTest.elm
+++ b/tests/SphereConvexTest.elm
@@ -16,7 +16,7 @@ addContacts : Test
 addContacts =
     let
         center =
-            { x = 0, y = 0, z = 7 }
+            Point3d.meters 0 0 7
 
         radius =
             5
@@ -69,7 +69,7 @@ addContacts =
                         (\position ->
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 boxHull
@@ -88,7 +88,7 @@ addContacts =
                         (\position ->
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 boxHull
@@ -102,7 +102,7 @@ addContacts =
                         (\position ->
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 octoHull
@@ -121,7 +121,7 @@ addContacts =
                         (\position ->
                             Collision.SphereConvex.addContacts
                                 identity
-                                (Frame3d.atPoint (Point3d.fromMeters center))
+                                (Frame3d.atPoint center)
                                 radius
                                 (Frame3d.atPoint (Point3d.fromMeters position))
                                 octoHull


### PR DESCRIPTION
* Introduce static and dynamic behaviors
* Introduce implicit centre of mass calculation for compound shapes while preserving body coordinates for end users
* Disallow planes and point of mass in compound bodies, because they have infinite or don't have any volume (might at some point add a separate `Body.points : List (Point Meters BodyCoordinates) -> data -> Body data` function if needed)
* Added missing ray casting support for planes
* World.simulate takes duration
* World.setGravity takes acceleration and direction