### PR TITLE
Introduce lock constraint

### DIFF
--- a/examples/CompoundVsLock.elm
+++ b/examples/CompoundVsLock.elm
@@ -1,0 +1,268 @@
+module CompoundVsLock exposing (main)
+
+{-| This demo shows two possible ways to create complex objects.
+One way is through a compound body out of multiple shapes.
+The second way is by using the lock constraint.
+-}
+
+import Acceleration
+import Block3d exposing (Block3d)
+import Browser
+import Common.Camera as Camera exposing (Camera)
+import Common.Events as Events
+import Common.Fps as Fps
+import Common.Meshes as Meshes exposing (Meshes)
+import Common.Scene as Scene
+import Common.Settings as Settings exposing (Settings, SettingsMsg, settings)
+import Direction3d
+import Duration
+import Frame3d
+import Html exposing (Html)
+import Html.Events exposing (onClick)
+import Internal.Constraint exposing (Constraint)
+import Length exposing (Meters)
+import Mass
+import Physics.Body as Body exposing (Body)
+import Physics.Constraint as Constraint exposing (Constraint)
+import Physics.Coordinates exposing (BodyCoordinates)
+import Physics.Shape as Shape
+import Physics.World as World exposing (World)
+import Point3d exposing (Point3d)
+
+
+{-| Give a name to each body, so that we can configure constraints
+-}
+type alias Data =
+    { meshes : Meshes
+    , name : String
+    }
+
+
+type alias Model =
+    { world : World Data
+    , fps : List Float
+    , settings : Settings
+    , camera : Camera
+    }
+
+
+type Msg
+    = ForSettings SettingsMsg
+    | Tick Float
+    | Resize Float Float
+    | Restart
+
+
+main : Program () Model Msg
+main =
+    Browser.element
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        }
+
+
+init : () -> ( Model, Cmd Msg )
+init _ =
+    ( { world = initialWorld
+      , fps = []
+      , settings = { settings | showSettings = True }
+      , camera =
+            Camera.camera
+                { from = { x = 0, y = 30, z = 20 }
+                , to = { x = 0, y = 0, z = 0 }
+                }
+      }
+    , Events.measureSize Resize
+    )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        ForSettings settingsMsg ->
+            ( { model
+                | settings = Settings.update settingsMsg model.settings
+              }
+            , Cmd.none
+            )
+
+        Tick dt ->
+            ( { model
+                | fps = Fps.update dt model.fps
+                , world = World.simulate (Duration.seconds (1 / 60)) model.world
+              }
+            , Cmd.none
+            )
+
+        Resize width height ->
+            ( { model | camera = Camera.resize width height model.camera }
+            , Cmd.none
+            )
+
+        Restart ->
+            ( { model | world = initialWorld }, Cmd.none )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    Sub.batch
+        [ Events.onResize Resize
+        , Events.onAnimationFrameDelta Tick
+        ]
+
+
+view : Model -> Html Msg
+view { settings, fps, world, camera } =
+    Html.div []
+        [ Scene.view
+            { settings = settings
+            , world = world
+            , camera = camera
+            , meshes = .meshes
+            , maybeRaycastResult = Nothing
+            , floorOffset = floorOffset
+            }
+        , Settings.view ForSettings
+            settings
+            [ Html.button [ onClick Restart ]
+                [ Html.text "Restart the demo" ]
+            ]
+        , if settings.showFpsMeter then
+            Fps.view fps (List.length (World.bodies world))
+
+          else
+            Html.text ""
+        ]
+
+
+initialWorld : World Data
+initialWorld =
+    let
+        lockedPosition =
+            Frame3d.atPoint (Point3d.meters -2 0 5)
+
+        compoundPosition =
+            Point3d.meters 2 0 5
+    in
+    World.empty
+        |> World.withGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
+        |> World.add floor
+        |> World.add
+            (compound
+                |> Body.moveTo compoundPosition
+            )
+        |> World.add
+            (box "first"
+                |> Body.moveTo (Point3d.placeIn lockedPosition pos1)
+            )
+        |> World.add
+            (box "second"
+                |> Body.moveTo (Point3d.placeIn lockedPosition pos2)
+            )
+        |> World.add
+            (box "third"
+                |> Body.moveTo (Point3d.placeIn lockedPosition pos3)
+            )
+        |> World.constrain lockBlocks
+
+
+lockBlocks : Body Data -> Body Data -> List Constraint
+lockBlocks b1 b2 =
+    case ( (Body.data b1).name, (Body.data b2).name ) of
+        ( "first", "second" ) ->
+            [ lockTwoBodies b1 b2 ]
+
+        ( "second", "third" ) ->
+            [ lockTwoBodies b1 b2 ]
+
+        _ ->
+            []
+
+
+lockTwoBodies : Body Data -> Body Data -> Constraint
+lockTwoBodies b1 b2 =
+    let
+        center1 =
+            Body.originPoint b1
+
+        center2 =
+            Body.originPoint b2
+
+        middle =
+            Point3d.midpoint center1 center2
+
+        frame1 =
+            Frame3d.atPoint (Point3d.relativeTo (Body.frame b1) middle)
+
+        frame2 =
+            Frame3d.atPoint (Point3d.relativeTo (Body.frame b2) middle)
+    in
+    Constraint.lock frame1 frame2
+
+
+{-| Shift the floor a little bit down
+-}
+floorOffset : { x : Float, y : Float, z : Float }
+floorOffset =
+    { x = 0, y = 0, z = -1 }
+
+
+{-| Floor has an empty mesh, because it is not rendered
+-}
+floor : Body Data
+floor =
+    Body.plane { meshes = Meshes.fromTriangles [], name = "floor" }
+        |> Body.moveTo (Point3d.fromMeters floorOffset)
+
+
+{-| A single box
+-}
+box : String -> Body Data
+box name =
+    Body.block block3d { meshes = Meshes.fromTriangles (Meshes.block block3d), name = name }
+        |> Body.withBehavior (Body.dynamic (Mass.kilograms 5))
+
+
+{-| A compound body made of three boxes
+-}
+compound : Body Data
+compound =
+    let
+        blocks =
+            List.map
+                (\center ->
+                    Block3d.placeIn (Frame3d.atPoint center) block3d
+                )
+                [ pos1, pos2, pos3 ]
+    in
+    Body.compound
+        (List.map Shape.block blocks)
+        { meshes = Meshes.fromTriangles (List.concatMap Meshes.block blocks), name = "compound" }
+        |> Body.withBehavior (Body.dynamic (Mass.kilograms 5))
+
+
+block3d : Block3d Meters BodyCoordinates
+block3d =
+    Block3d.centeredOn
+        Frame3d.atOrigin
+        ( Length.meters 1
+        , Length.meters 1
+        , Length.meters 1
+        )
+
+
+pos1 : Point3d Meters BodyCoordinates
+pos1 =
+    Point3d.meters -0.5 0 -0.5
+
+
+pos2 : Point3d Meters BodyCoordinates
+pos2 =
+    Point3d.meters -0.5 0 0.5
+
+
+pos3 : Point3d Meters BodyCoordinates
+pos3 =
+    Point3d.meters 0.5 0 0.5

--- a/src/Internal/Constraint.elm
+++ b/src/Internal/Constraint.elm
@@ -13,6 +13,7 @@ type Protected
 type Constraint coordinates
     = PointToPoint Vec3 Vec3
     | Hinge Vec3 Vec3 Vec3 Vec3
+    | Lock Vec3 Vec3 Vec3 Vec3 Vec3 Vec3 Vec3 Vec3
     | Distance Float
 
 
@@ -41,6 +42,17 @@ relativeToCenterOfMass centerOfMassFrame3d1 centerOfMassFrame3d2 (Protected cons
                 (Transform3d.directionRelativeTo centerOfMassFrame3d1 axis1)
                 (Transform3d.pointRelativeTo centerOfMassFrame3d2 pivot2)
                 (Transform3d.directionRelativeTo centerOfMassFrame3d2 axis2)
+
+        Lock pivot1 x1 y1 z1 pivot2 x2 y2 z2 ->
+            Lock
+                (Transform3d.pointRelativeTo centerOfMassFrame3d1 pivot1)
+                (Transform3d.directionRelativeTo centerOfMassFrame3d1 x1)
+                (Transform3d.directionRelativeTo centerOfMassFrame3d1 y1)
+                (Transform3d.directionRelativeTo centerOfMassFrame3d1 z1)
+                (Transform3d.pointRelativeTo centerOfMassFrame3d2 pivot2)
+                (Transform3d.directionRelativeTo centerOfMassFrame3d2 x2)
+                (Transform3d.directionRelativeTo centerOfMassFrame3d2 y2)
+                (Transform3d.directionRelativeTo centerOfMassFrame3d2 z2)
 
         Distance length ->
             Distance length

--- a/src/Physics/Constraint.elm
+++ b/src/Physics/Constraint.elm
@@ -1,18 +1,19 @@
 module Physics.Constraint exposing
     ( Constraint
-    , pointToPoint, hinge, distance
+    , pointToPoint, hinge, distance, lock
     )
 
 {-|
 
 @docs Constraint
 
-@docs pointToPoint, hinge, distance
+@docs pointToPoint, hinge, distance, lock
 
 -}
 
 import Axis3d exposing (Axis3d)
 import Direction3d
+import Frame3d exposing (Frame3d)
 import Internal.Constraint as Internal exposing (Protected(..))
 import Length exposing (Length, Meters)
 import Physics.Coordinates exposing (BodyCoordinates)
@@ -60,6 +61,49 @@ hinge axis3d1 axis3d2 =
             Direction3d.unwrap (Axis3d.direction axis3d2)
     in
     Protected (Internal.Hinge pivot1 axis1 pivot2 axis2)
+
+
+{-| Keep two bodies connected with each other and remove all degrees of freedom between bodies.
+-}
+lock :
+    Frame3d Meters BodyCoordinates {}
+    -> Frame3d Meters BodyCoordinates {}
+    -> Constraint
+lock frame3d1 frame3d2 =
+    let
+        pivot1 =
+            Point3d.toMeters (Frame3d.originPoint frame3d1)
+
+        x1 =
+            Direction3d.unwrap (Frame3d.xDirection frame3d1)
+
+        y1 =
+            Direction3d.unwrap (Frame3d.yDirection frame3d1)
+
+        z1 =
+            if Frame3d.isRightHanded frame3d1 then
+                Direction3d.unwrap (Frame3d.zDirection frame3d1)
+
+            else
+                Direction3d.unwrap (Direction3d.reverse (Frame3d.zDirection frame3d1))
+
+        pivot2 =
+            Point3d.toMeters (Frame3d.originPoint frame3d2)
+
+        x2 =
+            Direction3d.unwrap (Frame3d.xDirection frame3d2)
+
+        y2 =
+            Direction3d.unwrap (Frame3d.yDirection frame3d2)
+
+        z2 =
+            if Frame3d.isRightHanded frame3d2 then
+                Direction3d.unwrap (Frame3d.zDirection frame3d2)
+
+            else
+                Direction3d.unwrap (Direction3d.reverse (Frame3d.zDirection frame3d2))
+    in
+    Protected (Internal.Lock pivot1 x1 y1 z1 pivot2 x2 y2 z2)
 
 
 {-| Keep the centers of two bodies at the constant distance


### PR DESCRIPTION
Addresses #92.

@CSchank There is a couple of issues revealed by the lock constraint. 

1. The behaviour seems to be different from the compound body. My guess is that the inertia calculation for a compound body is oversimplified, because it takes the bounding box and assumes the cuboid shape — I will try to address this separately.
2. There is still some jitter, that is visible if you e.g. show the collision points. Currently, there is no way to supply collision masks or any other mechanism to prevent collisions between locked bodies.

![compoundvslocked](https://user-images.githubusercontent.com/43472/90441356-18fd4d00-e0d9-11ea-94f2-cd7a66380589.gif)

Maybe this is ok for your use case for now. It may take some time for me to address these things and release a new version. In the mean time, maybe you can inline the code from this branch into your project.

