### PR TITLE
Support for unsafeConvex shape

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -17,6 +17,7 @@
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "ianmackenzie/elm-geometry": "3.0.0 <= v < 4.0.0",
+        "ianmackenzie/elm-triangular-mesh": "1.0.4 <= v < 2.0.0",
         "ianmackenzie/elm-units": "2.2.0 <= v < 3.0.0"
     },
     "test-dependencies": {

--- a/examples/Common/Meshes.elm
+++ b/examples/Common/Meshes.elm
@@ -7,14 +7,16 @@ module Common.Meshes exposing
     , fromTriangles
     , normal
     , sphere
+    , triangularMesh
     )
 
 import Block3d exposing (Block3d)
 import Length exposing (Meters, inMeters)
 import Math.Vector3 as Vec3 exposing (Vec3, vec3)
 import Physics.Coordinates exposing (BodyCoordinates)
-import Point3d
+import Point3d exposing (Point3d)
 import Sphere3d exposing (Sphere3d)
+import TriangularMesh exposing (TriangularMesh)
 import WebGL exposing (Mesh)
 
 
@@ -134,6 +136,19 @@ block block3d =
     , facet v1 v2 v6
     , facet v6 v5 v1
     ]
+
+
+triangularMesh : TriangularMesh (Point3d Meters BodyCoordinates) -> List ( Attributes, Attributes, Attributes )
+triangularMesh mesh =
+    mesh
+        |> TriangularMesh.mapVertices Point3d.toMeters
+        |> TriangularMesh.faceVertices
+        |> List.map
+            (\( v1, v2, v3 ) ->
+                facet (Vec3.fromRecord v1)
+                    (Vec3.fromRecord v2)
+                    (Vec3.fromRecord v3)
+            )
 
 
 pyramid : Float -> Float -> List ( Attributes, Attributes, Attributes )

--- a/examples/UnsafeConvex.elm
+++ b/examples/UnsafeConvex.elm
@@ -1,0 +1,291 @@
+module UnsafeConvex exposing (main)
+
+{-| This is used to demonstrate loading `unsafeConvex` shape from the OBJ file!
+-}
+
+import Acceleration
+import Browser
+import Common.Camera as Camera exposing (Camera)
+import Common.Events as Events
+import Common.Fps as Fps
+import Common.Meshes as Meshes exposing (Meshes)
+import Common.Scene as Scene
+import Common.Settings as Settings exposing (Settings, SettingsMsg, settings)
+import Direction3d
+import Duration
+import Frame3d
+import Html exposing (Html)
+import Html.Events exposing (onClick)
+import Length
+import Mass
+import Obj.Decode
+import Physics.Body as Body exposing (Body)
+import Physics.Material as Material
+import Physics.Shape as Shape
+import Physics.World as World exposing (World)
+import Point3d
+
+
+type alias Model =
+    { world : World Meshes
+    , fps : List Float
+    , settings : Settings
+    , camera : Camera
+    }
+
+
+type Msg
+    = ForSettings SettingsMsg
+    | Tick Float
+    | Resize Float Float
+    | Restart
+
+
+main : Program () Model Msg
+main =
+    Browser.element
+        { init = init
+        , update = update
+        , subscriptions = subscriptions
+        , view = view
+        }
+
+
+init : () -> ( Model, Cmd Msg )
+init _ =
+    ( { world = initialWorld
+      , fps = []
+      , settings = { settings | showFpsMeter = True }
+      , camera =
+            Camera.camera
+                { from = { x = 0, y = 30, z = 20 }
+                , to = { x = 0, y = 0, z = 0 }
+                }
+      }
+    , Events.measureSize Resize
+    )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        ForSettings settingsMsg ->
+            ( { model
+                | settings = Settings.update settingsMsg model.settings
+              }
+            , Cmd.none
+            )
+
+        Tick dt ->
+            ( { model
+                | fps = Fps.update dt model.fps
+                , world = World.simulate (Duration.seconds (1 / 60)) model.world
+              }
+            , Cmd.none
+            )
+
+        Resize width height ->
+            ( { model | camera = Camera.resize width height model.camera }
+            , Cmd.none
+            )
+
+        Restart ->
+            ( { model | world = initialWorld }, Cmd.none )
+
+
+subscriptions : Model -> Sub Msg
+subscriptions _ =
+    Sub.batch
+        [ Events.onResize Resize
+        , Events.onAnimationFrameDelta Tick
+        ]
+
+
+view : Model -> Html Msg
+view { settings, fps, world, camera } =
+    Html.div []
+        [ Scene.view
+            { settings = settings
+            , world = world
+            , camera = camera
+            , meshes = identity
+            , maybeRaycastResult = Nothing
+            , floorOffset = floorOffset
+            }
+        , Settings.view ForSettings
+            settings
+            [ Html.button [ onClick Restart ]
+                [ Html.text "Restart the demo" ]
+            ]
+        , if settings.showFpsMeter then
+            Fps.view fps (List.length (World.bodies world))
+
+          else
+            Html.text ""
+        ]
+
+
+initialWorld : World Meshes
+initialWorld =
+    World.empty
+        |> World.withGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
+        |> World.add floor
+        |> World.add (icoSphere |> Body.moveTo (Point3d.meters 0 0 8))
+        |> World.add (icoSphere |> Body.moveTo (Point3d.meters 0.3 0 5))
+
+
+{-| Shift the floor a little bit down
+-}
+floorOffset : { x : Float, y : Float, z : Float }
+floorOffset =
+    { x = 0, y = 0, z = -1 }
+
+
+{-| Floor has an empty mesh, because it is not rendered
+-}
+floor : Body Meshes
+floor =
+    Body.plane (Meshes.fromTriangles [])
+        |> Body.moveTo (Point3d.fromMeters floorOffset)
+
+
+icoSphere : Body Meshes
+icoSphere =
+    case Obj.Decode.decodeString Length.meters (Obj.Decode.trianglesIn Frame3d.atOrigin) icoSphereObj of
+        Ok triangularMesh ->
+            Body.compound [ Shape.unsafeConvex triangularMesh ] (Meshes.fromTriangles (Meshes.triangularMesh triangularMesh))
+                |> Body.withMaterial (Material.custom { friction = 0.4, bounciness = 0.5 })
+                |> Body.withBehavior (Body.dynamic (Mass.kilograms 5))
+
+        Err _ ->
+            Body.compound [] (Meshes.fromTriangles [])
+
+
+icoSphereObj : String
+icoSphereObj =
+    """# Blender v2.83.3 OBJ File: 'icosphere'
+# www.blender.org
+v 0.000000 0.000000 -1.000000
+v 0.723607 -0.525725 -0.447220
+v -0.276388 -0.850649 -0.447220
+v -0.894426 0.000000 -0.447216
+v -0.276388 0.850649 -0.447220
+v 0.723607 0.525725 -0.447220
+v 0.276388 -0.850649 0.447220
+v -0.723607 -0.525725 0.447220
+v -0.723607 0.525725 0.447220
+v 0.276388 0.850649 0.447220
+v 0.894426 0.000000 0.447216
+v 0.000000 0.000000 1.000000
+v -0.162456 -0.499995 -0.850654
+v 0.425323 -0.309011 -0.850654
+v 0.262869 -0.809012 -0.525738
+v 0.850648 0.000000 -0.525736
+v 0.425323 0.309011 -0.850654
+v -0.525730 0.000000 -0.850652
+v -0.688189 -0.499997 -0.525736
+v -0.162456 0.499995 -0.850654
+v -0.688189 0.499997 -0.525736
+v 0.262869 0.809012 -0.525738
+v 0.951058 -0.309013 0.000000
+v 0.951058 0.309013 0.000000
+v 0.000000 -1.000000 0.000000
+v 0.587786 -0.809017 0.000000
+v -0.951058 -0.309013 0.000000
+v -0.587786 -0.809017 0.000000
+v -0.587786 0.809017 0.000000
+v -0.951058 0.309013 0.000000
+v 0.587786 0.809017 0.000000
+v 0.000000 1.000000 0.000000
+v 0.688189 -0.499997 0.525736
+v -0.262869 -0.809012 0.525738
+v -0.850648 0.000000 0.525736
+v -0.262869 0.809012 0.525738
+v 0.688189 0.499997 0.525736
+v 0.162456 -0.499995 0.850654
+v 0.525730 0.000000 0.850652
+v -0.425323 -0.309011 0.850654
+v -0.425323 0.309011 0.850654
+v 0.162456 0.499995 0.850654
+s off
+f 1 14 13
+f 2 14 16
+f 1 13 18
+f 1 18 20
+f 1 20 17
+f 2 16 23
+f 3 15 25
+f 4 19 27
+f 5 21 29
+f 6 22 31
+f 2 23 26
+f 3 25 28
+f 4 27 30
+f 5 29 32
+f 6 31 24
+f 7 33 38
+f 8 34 40
+f 9 35 41
+f 10 36 42
+f 11 37 39
+f 39 42 12
+f 39 37 42
+f 37 10 42
+f 42 41 12
+f 42 36 41
+f 36 9 41
+f 41 40 12
+f 41 35 40
+f 35 8 40
+f 40 38 12
+f 40 34 38
+f 34 7 38
+f 38 39 12
+f 38 33 39
+f 33 11 39
+f 24 37 11
+f 24 31 37
+f 31 10 37
+f 32 36 10
+f 32 29 36
+f 29 9 36
+f 30 35 9
+f 30 27 35
+f 27 8 35
+f 28 34 8
+f 28 25 34
+f 25 7 34
+f 26 33 7
+f 26 23 33
+f 23 11 33
+f 31 32 10
+f 31 22 32
+f 22 5 32
+f 29 30 9
+f 29 21 30
+f 21 4 30
+f 27 28 8
+f 27 19 28
+f 19 3 28
+f 25 26 7
+f 25 15 26
+f 15 2 26
+f 23 24 11
+f 23 16 24
+f 16 6 24
+f 17 22 6
+f 17 20 22
+f 20 5 22
+f 20 21 5
+f 20 18 21
+f 18 4 21
+f 18 19 4
+f 18 13 19
+f 13 3 19
+f 16 17 6
+f 16 14 17
+f 14 1 17
+f 13 15 3
+f 13 14 15
+f 14 2 15
+"""

--- a/examples/UnsafeConvex.elm
+++ b/examples/UnsafeConvex.elm
@@ -130,7 +130,7 @@ initialWorld =
     World.empty
         |> World.withGravity (Acceleration.metersPerSecondSquared 9.80665) Direction3d.negativeZ
         |> World.add floor
-        |> World.add (icoSphere |> Body.moveTo (Point3d.meters 0 0 8))
+        |> World.add (cube |> Body.moveTo (Point3d.meters 0 0 8))
         |> World.add (icoSphere |> Body.moveTo (Point3d.meters 0.3 0 5))
 
 
@@ -159,6 +159,39 @@ icoSphere =
 
         Err _ ->
             Body.compound [] (Meshes.fromTriangles [])
+
+cube : Body Meshes
+cube =
+    case Obj.Decode.decodeString Length.meters (Obj.Decode.trianglesIn Frame3d.atOrigin) cubeObj of
+        Ok triangularMesh ->
+            Body.compound [ Shape.unsafeConvex triangularMesh ] (Meshes.fromTriangles (Meshes.triangularMesh triangularMesh))
+                |> Body.withMaterial (Material.custom { friction = 0.4, bounciness = 0.5 })
+                |> Body.withBehavior (Body.dynamic (Mass.kilograms 5))
+
+        Err _ ->
+            Body.compound [] (Meshes.fromTriangles [])
+
+
+
+cubeObj : String
+cubeObj =
+    """# Blender v2.83.3 OBJ File: 'cube'
+# www.blender.org
+v 1.000000 1.000000 -1.000000
+v 1.000000 -1.000000 -1.000000
+v 1.000000 1.000000 1.000000
+v 1.000000 -1.000000 1.000000
+v -1.000000 1.000000 -1.000000
+v -1.000000 -1.000000 -1.000000
+v -1.000000 1.000000 1.000000
+v -1.000000 -1.000000 1.000000
+f 1 5 7 3
+f 4 3 7 8
+f 8 7 5 6
+f 6 2 4 8
+f 2 1 3 4
+f 6 5 1 2
+"""
 
 
 icoSphereObj : String

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -7,26 +7,30 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
             "elm/html": "1.0.0",
-            "elm/json": "1.0.0",
+            "elm/json": "1.1.3",
             "elm/random": "1.0.0",
             "elm-explorations/linear-algebra": "1.0.3",
             "elm-explorations/webgl": "1.1.2",
-            "ianmackenzie/elm-geometry": "3.0.0",
-            "ianmackenzie/elm-geometry-linear-algebra-interop": "2.0.1",
-            "ianmackenzie/elm-units": "2.2.0"
+            "ianmackenzie/elm-geometry": "3.6.0",
+            "ianmackenzie/elm-geometry-linear-algebra-interop": "2.0.2",
+            "ianmackenzie/elm-triangular-mesh": "1.0.4",
+            "ianmackenzie/elm-units": "2.6.0",
+            "w0rm/elm-obj-file": "1.0.0"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
+            "elm/http": "2.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
             "ianmackenzie/elm-1d-parameter": "1.0.1",
             "ianmackenzie/elm-float-extra": "1.1.0",
             "ianmackenzie/elm-interval": "2.0.0",
-            "ianmackenzie/elm-triangular-mesh": "1.0.2",
-            "ianmackenzie/elm-units-interval": "1.0.0"
+            "ianmackenzie/elm-units-interval": "1.1.0"
         }
     },
     "test-dependencies": {

--- a/src/Internal/Body.elm
+++ b/src/Internal/Body.elm
@@ -108,7 +108,7 @@ compound shapes data =
 
         movedShapes : List (Shape CenterOfMassCoordinates)
         movedShapes =
-            Shape.shapesPlaceIn inverseCenterOfMassTransform3d shapes
+            Shape.shapesPlaceInWithInertia inverseCenterOfMassTransform3d shapes
     in
     updateMassProperties
         { id = -1
@@ -163,8 +163,8 @@ updateMassProperties ({ mass, shapes } as body) =
     in
     { body
         | invMass = invMass
-        , invInertia = Mat3.inverse inertia
-        , invInertiaWorld = Transform3d.inertiaRotateIn body.transform3d invInertia
+        , invInertia = invInertia
+        , invInertiaWorld = Transform3d.invertedInertiaRotateIn body.transform3d invInertia
     }
 
 

--- a/src/Internal/Matrix3.elm
+++ b/src/Internal/Matrix3.elm
@@ -215,13 +215,13 @@ tetrahedronInertia m p0 p1 p2 p3 =
             ix + iy
 
         ixy =
-            m / 10 * (2 * (x1 * y1 + x2 * y2 + x3 * y3) + x1 * y2 + x2 * y1 + x1 * y3 + x3 * y1 + x2 * y3 + x3 * y2)
+            m / 20 * (2 * (x1 * y1 + x2 * y2 + x3 * y3) + x1 * y2 + x2 * y1 + x1 * y3 + x3 * y1 + x2 * y3 + x3 * y2)
 
         iyz =
-            m / 10 * (2 * (z1 * y1 + z2 * y2 + z3 * y3) + z1 * y2 + z2 * y1 + z1 * y3 + z3 * y1 + z2 * y3 + z3 * y2)
+            m / 20 * (2 * (z1 * y1 + z2 * y2 + z3 * y3) + z1 * y2 + z2 * y1 + z1 * y3 + z3 * y1 + z2 * y3 + z3 * y2)
 
         izx =
-            m / 10 * (2 * (x1 * z1 + x2 * z2 + x3 * z3) + x1 * z2 + x2 * z1 + x1 * z3 + x3 * z1 + x2 * z3 + x3 * z2)
+            m / 20 * (2 * (x1 * z1 + x2 * z2 + x3 * z3) + x1 * z2 + x2 * z1 + x1 * z3 + x3 * z1 + x2 * z3 + x3 * z2)
     in
     { m11 = ixx
     , m12 = ixy

--- a/src/Internal/Matrix3.elm
+++ b/src/Internal/Matrix3.elm
@@ -239,12 +239,12 @@ tetrahedronInertia m p0 p1 p2 p3 =
             m / 20 * (2 * (x1 * z1 + x2 * z2 + x3 * z3) + x1 * z2 + x2 * z1 + x1 * z3 + x3 * z1 + x2 * z3 + x3 * z2)
     in
     { m11 = ixx
-    , m12 = ixy
-    , m13 = izx
-    , m21 = ixy
+    , m12 = -ixy
+    , m13 = -izx
+    , m21 = -ixy
     , m22 = iyy
-    , m23 = iyz
-    , m31 = izx
-    , m32 = iyz
+    , m23 = -iyz
+    , m31 = -izx
+    , m32 = -iyz
     , m33 = izz
     }

--- a/src/Internal/Matrix3.elm
+++ b/src/Internal/Matrix3.elm
@@ -6,6 +6,7 @@ module Internal.Matrix3 exposing
     , pointInertia
     , rotateInertia
     , scale
+    , sub
     , tetrahedronInertia
     , transpose
     , zero
@@ -114,6 +115,20 @@ add a b =
     }
 
 
+sub : Mat3 -> Mat3 -> Mat3
+sub a b =
+    { m11 = a.m11 - b.m11
+    , m21 = a.m21 - b.m21
+    , m31 = a.m31 - b.m31
+    , m12 = a.m12 - b.m12
+    , m22 = a.m22 - b.m22
+    , m32 = a.m32 - b.m32
+    , m13 = a.m13 - b.m13
+    , m23 = a.m23 - b.m23
+    , m33 = a.m33 - b.m33
+    }
+
+
 {-| Flip the matrix across the diagonal by swapping row index and column
 index.
 -}
@@ -197,13 +212,13 @@ tetrahedronInertia m p0 p1 p2 p3 =
             p3.z - p0.z
 
         ix =
-            m / 10 * (x1 * x1 + x2 * x2 + x1 * x2 + x1 * x3 + x2 * x3)
+            m / 10 * (x1 * x1 + x2 * x2 + x3 * x3 + x1 * x2 + x1 * x3 + x2 * x3)
 
         iy =
-            m / 10 * (x1 * x1 + x2 * x2 + x1 * x2 + x1 * x3 + x2 * x3)
+            m / 10 * (y1 * y1 + y2 * y2 + y3 * y3 + y1 * y2 + y1 * y3 + y2 * y3)
 
         iz =
-            m / 10 * (x1 * x1 + x2 * x2 + x1 * x2 + x1 * x3 + x2 * x3)
+            m / 10 * (z1 * z1 + z2 * z2 + z3 * z3 + z1 * z2 + z1 * z3 + z2 * z3)
 
         ixx =
             iy + iz

--- a/src/Internal/Matrix3.elm
+++ b/src/Internal/Matrix3.elm
@@ -6,11 +6,12 @@ module Internal.Matrix3 exposing
     , pointInertia
     , rotateInertia
     , scale
+    , tetrahedronInertia
     , transpose
     , zero
     )
 
-{-| -}
+import Internal.Vector3 exposing (Vec3)
 
 
 {-| 3x3 matrix type
@@ -162,4 +163,73 @@ pointInertia m x y z =
     , m13 = m31
     , m23 = m32
     , m33 = m * (x * x + y * y)
+    }
+
+
+tetrahedronInertia : Float -> Vec3 -> Vec3 -> Vec3 -> Vec3 -> Mat3
+tetrahedronInertia m p0 p1 p2 p3 =
+    let
+        x1 =
+            p1.x - p0.x
+
+        x2 =
+            p2.x - p0.x
+
+        x3 =
+            p3.x - p0.x
+
+        y1 =
+            p1.y - p0.y
+
+        y2 =
+            p2.y - p0.y
+
+        y3 =
+            p3.y - p0.y
+
+        z1 =
+            p1.z - p0.z
+
+        z2 =
+            p2.z - p0.z
+
+        z3 =
+            p3.z - p0.z
+
+        ix =
+            m / 10 * (x1 * x1 + x2 * x2 + x1 * x2 + x1 * x3 + x2 * x3)
+
+        iy =
+            m / 10 * (x1 * x1 + x2 * x2 + x1 * x2 + x1 * x3 + x2 * x3)
+
+        iz =
+            m / 10 * (x1 * x1 + x2 * x2 + x1 * x2 + x1 * x3 + x2 * x3)
+
+        ixx =
+            iy + iz
+
+        iyy =
+            ix + iz
+
+        izz =
+            ix + iy
+
+        ixy =
+            m / 10 * (2 * (x1 * y1 + x2 * y2 + x3 * y3) + x1 * y2 + x2 * y1 + x1 * y3 + x3 * y1 + x2 * y3 + x3 * y2)
+
+        iyz =
+            m / 10 * (2 * (z1 * y1 + z2 * y2 + z3 * y3) + z1 * y2 + z2 * y1 + z1 * y3 + z3 * y1 + z2 * y3 + z3 * y2)
+
+        izx =
+            m / 10 * (2 * (x1 * z1 + x2 * z2 + x3 * z3) + x1 * z2 + x2 * z1 + x1 * z3 + x3 * z1 + x2 * z3 + x3 * z2)
+    in
+    { m11 = ixx
+    , m12 = ixy
+    , m13 = izx
+    , m21 = ixy
+    , m22 = iyy
+    , m23 = iyz
+    , m31 = izx
+    , m32 = iyz
+    , m33 = izz
     }

--- a/src/Internal/Shape.elm
+++ b/src/Internal/Shape.elm
@@ -6,6 +6,7 @@ module Internal.Shape exposing
     , inertia
     , raycast
     , shapesPlaceIn
+    , shapesPlaceInWithInertia
     , volume
     )
 
@@ -89,6 +90,40 @@ shapesPlaceInHelp transform3d shapes result =
 
                     Sphere sphere ->
                         Sphere (Sphere.placeIn transform3d sphere)
+
+                    Particle position ->
+                        Particle (Transform3d.pointPlaceIn transform3d position)
+                 )
+                    :: result
+                )
+
+        [] ->
+            result
+
+
+{-| Transforms shapes, reverses the original order
+-}
+shapesPlaceInWithInertia : Transform3d coordinates { defines : originalCoords } -> List (Shape originalCoords) -> List (Shape coordinates)
+shapesPlaceInWithInertia transform3d shapes =
+    shapesPlaceInWithInertiaHelp transform3d shapes []
+
+
+shapesPlaceInWithInertiaHelp : Transform3d coordinates { defines : originalCoords } -> List (Shape originalCoords) -> List (Shape coordinates) -> List (Shape coordinates)
+shapesPlaceInWithInertiaHelp transform3d shapes result =
+    case shapes of
+        shape :: remainingShapes ->
+            shapesPlaceInWithInertiaHelp
+                transform3d
+                remainingShapes
+                ((case shape of
+                    Convex convex ->
+                        Convex (Convex.placeInWithInertia transform3d convex)
+
+                    Plane plane ->
+                        Plane (Plane.placeIn transform3d plane)
+
+                    Sphere sphere ->
+                        Sphere (Sphere.placeInWithInertia transform3d sphere)
 
                     Particle position ->
                         Particle (Transform3d.pointPlaceIn transform3d position)

--- a/src/Internal/SolverBody.elm
+++ b/src/Internal/SolverBody.elm
@@ -93,7 +93,7 @@ toBody { dt, gravity } { body, vX, vY, vZ, wX, wY, wZ } =
     , angularDamping = body.angularDamping
     , invMass = body.invMass
     , invInertia = body.invInertia
-    , invInertiaWorld = Transform3d.inertiaRotateIn newTransform3d body.invInertia
+    , invInertiaWorld = Transform3d.invertedInertiaRotateIn newTransform3d body.invInertia
 
     -- clear forces
     , force = Vec3.zero

--- a/src/Physics/Shape.elm
+++ b/src/Physics/Shape.elm
@@ -1,8 +1,8 @@
-module Physics.Shape exposing (Shape, block, sphere)
+module Physics.Shape exposing (Shape, block, sphere, unsafeConvex)
 
 {-|
 
-@docs Shape, block, sphere
+@docs Shape, block, sphere, unsafeConvex
 
 -}
 
@@ -13,10 +13,11 @@ import Internal.Shape as Internal exposing (Protected(..))
 import Internal.Transform3d as Transform3d
 import Length exposing (Meters)
 import Physics.Coordinates exposing (BodyCoordinates)
-import Point3d
+import Point3d exposing (Point3d)
 import Shapes.Convex as Convex
 import Shapes.Sphere as Sphere
 import Sphere3d exposing (Sphere3d)
+import TriangularMesh exposing (TriangularMesh)
 
 
 {-| Shapes are only needed for creating [compound](Physics-Body#compound) bodies.
@@ -94,4 +95,22 @@ sphere sphere3d =
             (Sphere.atOrigin radius
                 |> Sphere.placeIn (Transform3d.atPoint origin)
             )
+        )
+
+
+{-| -}
+unsafeConvex : TriangularMesh (Point3d Meters BodyCoordinates) -> Shape
+unsafeConvex triangularMesh =
+    let
+        faceIndices =
+            TriangularMesh.faceIndices triangularMesh
+
+        vertices =
+            triangularMesh
+                |> TriangularMesh.mapVertices Point3d.toMeters
+                |> TriangularMesh.vertices
+    in
+    Protected
+        (Internal.Convex
+            (Convex.fromTriangularMesh faceIndices vertices)
         )

--- a/src/Physics/Shape.elm
+++ b/src/Physics/Shape.elm
@@ -25,10 +25,12 @@ import TriangularMesh exposing (TriangularMesh)
 If you need a body with a single shape, use the corresponding functions
 from the [Physics.Body](Physics-Body) module.
 
-The only supported shapes are:
+The supported primitive shapes are:
 
   - [block](#block),
   - [sphere](#sphere).
+
+For the more complex cases use the [unsafeConvex](#unsafeConvex) shape.
 
 Shapes are defined in the body coordinate system.
 
@@ -98,7 +100,16 @@ sphere sphere3d =
         )
 
 
-{-| -}
+{-| Create a shape from the triangular mesh. This is useful if you want
+to import from Blender using [elm-obj-file](https://package.elm-lang.org/packages/w0rm/elm-obj-file/latest).
+
+**Note:** this may cause unexpected behavior, unless you make sure that:
+
+  - the mesh is a [convex polyhedron](https://en.wikipedia.org/wiki/Convex_polytope);
+  - the mesh is watertight, consisting of one closed surface;
+  - all faces have counterclockwise [winding order](https://cmichel.io/understanding-front-faces-winding-order-and-normals).
+
+-}
 unsafeConvex : TriangularMesh (Point3d Meters BodyCoordinates) -> Shape
 unsafeConvex triangularMesh =
     let

--- a/src/Shapes/Convex.elm
+++ b/src/Shapes/Convex.elm
@@ -447,7 +447,8 @@ fromBlock sizeX sizeY sizeZ =
     in
     { faces =
         -- faces vertices are reversed for local coordinates
-        -- then they become correct after transformation
+        -- then they become correct after the initial transformation
+        -- that is applied to the block shape in the constructor
         -- this is needed for performance
         [ { vertices = List.reverse [ v3, v2, v1, v0 ]
           , normal = Vec3.zNegative

--- a/src/Shapes/Convex.elm
+++ b/src/Shapes/Convex.elm
@@ -431,18 +431,18 @@ fromBlock sizeX sizeY sizeZ =
             { x = -x, y = y, z = z }
 
         volume =
-            x * y * z * 8
+            sizeX * sizeY * sizeZ
 
         inertia =
-            { m11 = 1.0 / 12.0 * volume * (sizeY * sizeY + sizeZ * sizeZ)
+            { m11 = volume / 12 * (sizeY * sizeY + sizeZ * sizeZ)
             , m21 = 0
             , m31 = 0
             , m12 = 0
-            , m22 = 1.0 / 12.0 * volume * (sizeX * sizeX + sizeZ * sizeZ)
+            , m22 = volume / 12 * (sizeX * sizeX + sizeZ * sizeZ)
             , m32 = 0
             , m13 = 0
             , m23 = 0
-            , m33 = 1.0 / 12.0 * volume * (sizeY * sizeY + sizeX * sizeX)
+            , m33 = volume / 12 * (sizeY * sizeY + sizeX * sizeX)
             }
     in
     { faces =

--- a/src/Shapes/Convex.elm
+++ b/src/Shapes/Convex.elm
@@ -8,6 +8,7 @@ module Shapes.Convex exposing
     , fromBlock
     , fromTriangularMesh
     , placeIn
+    , placeInWithInertia
     , raycast
     )
 
@@ -44,7 +45,21 @@ placeIn transform3d { faces, vertices, uniqueEdges, uniqueNormals, position, vol
     , uniqueNormals = Transform3d.directionsPlaceIn transform3d uniqueNormals
     , volume = volume
     , position = Transform3d.pointPlaceIn transform3d position
-    , inertia = Transform3d.inertiaPlaceIn transform3d volume inertia
+    , inertia = Transform3d.inertiaRotateIn transform3d inertia
+    }
+
+
+placeInWithInertia : Transform3d coordinates defines -> Convex -> Convex
+placeInWithInertia transform3d { faces, vertices, uniqueEdges, uniqueNormals, position, volume, inertia } =
+    { faces = facesPlaceInHelp transform3d faces []
+    , vertices = Transform3d.pointsPlaceIn transform3d vertices
+    , uniqueEdges = Transform3d.directionsPlaceIn transform3d uniqueEdges
+    , uniqueNormals = Transform3d.directionsPlaceIn transform3d uniqueNormals
+    , volume = volume
+    , position = Transform3d.pointPlaceIn transform3d position
+
+    -- TODO: take this out only when we need to combine inertias in compound body
+    , inertia = Transform3d.inertiaPlaceIn transform3d position volume inertia
     }
 
 

--- a/src/Shapes/Convex.elm
+++ b/src/Shapes/Convex.elm
@@ -164,7 +164,7 @@ convexMassProperties center faceIndices vertices cX cY cZ totalVolume totalInert
                     , z = cZ / totalVolume
                     }
 
-                offsetInertia =
+                pointInertia =
                     Mat3.pointInertia totalVolume
                         (centerOfMass.x - center.x)
                         (centerOfMass.y - center.y)
@@ -172,7 +172,9 @@ convexMassProperties center faceIndices vertices cX cY cZ totalVolume totalInert
             in
             ( totalVolume
             , centerOfMass
-            , Mat3.add offsetInertia totalInertia
+              -- inertia about origin = inertia about center of mass + point inertia about origin
+              -- inertia about center of mass = inertia about origin - point inertia about origin
+            , Mat3.sub totalInertia pointInertia
             )
 
 

--- a/src/Shapes/Sphere.elm
+++ b/src/Shapes/Sphere.elm
@@ -3,6 +3,7 @@ module Shapes.Sphere exposing
     , atOrigin
     , expandBoundingSphereRadius
     , placeIn
+    , placeInWithInertia
     , raycast
     )
 
@@ -51,7 +52,16 @@ placeIn : Transform3d coordinates defines -> Sphere -> Sphere
 placeIn transform3d { radius, position, volume, inertia } =
     { radius = radius
     , volume = volume
-    , inertia = Transform3d.inertiaPlaceIn transform3d volume inertia
+    , inertia = inertia
+    , position = Transform3d.pointPlaceIn transform3d position
+    }
+
+
+placeInWithInertia : Transform3d coordinates defines -> Sphere -> Sphere
+placeInWithInertia transform3d { radius, position, volume, inertia } =
+    { radius = radius
+    , volume = volume
+    , inertia = Transform3d.inertiaPlaceIn transform3d position volume inertia
     , position = Transform3d.pointPlaceIn transform3d position
     }
 

--- a/tests/ConvexTest.elm
+++ b/tests/ConvexTest.elm
@@ -1,6 +1,7 @@
 module ConvexTest exposing
     ( addFaceEdges
     , boxUniqueEdges
+    , extendContour
     , initFaceNormal
     , initUniqueEdges
     )
@@ -13,6 +14,36 @@ import Internal.Const as Const
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Shapes.Convex as Convex exposing (Convex)
 import Test exposing (Test, describe, test)
+
+
+extendContour : Test
+extendContour =
+    describe "Convex.extendContour"
+        [ test "works for the first point" <|
+            \_ ->
+                Convex.extendContour ( 666, 4, 3 ) [ 1, 2, 3, 4, 5, 6 ]
+                    |> Expect.equal [ 1, 2, 3, 666, 4, 5, 6 ]
+        , test "works for the second point" <|
+            \_ ->
+                Convex.extendContour ( 3, 666, 4 ) [ 1, 2, 3, 4, 5, 6 ]
+                    |> Expect.equal [ 1, 2, 3, 666, 4, 5, 6 ]
+        , test "works for the third point" <|
+            \_ ->
+                Convex.extendContour ( 4, 3, 666 ) [ 1, 2, 3, 4, 5, 6 ]
+                    |> Expect.equal [ 1, 2, 3, 666, 4, 5, 6 ]
+        , test "works for the first point at the end" <|
+            \_ ->
+                Convex.extendContour ( 666, 1, 6 ) [ 1, 2, 3, 4, 5, 6 ]
+                    |> Expect.equal [ 1, 2, 3, 4, 5, 6, 666 ]
+        , test "works for the second point at the end" <|
+            \_ ->
+                Convex.extendContour ( 6, 666, 1 ) [ 1, 2, 3, 4, 5, 6 ]
+                    |> Expect.equal [ 1, 2, 3, 4, 5, 6, 666 ]
+        , test "works for the third point at the end" <|
+            \_ ->
+                Convex.extendContour ( 1, 6, 666 ) [ 1, 2, 3, 4, 5, 6 ]
+                    |> Expect.equal [ 1, 2, 3, 4, 5, 6, 666 ]
+        ]
 
 
 initFaceNormal : Test
@@ -110,10 +141,10 @@ initFaceNormal =
             ]
 
         faceIndices =
-            [ 0, 1, 2 ]
+            ( 0, 1, 2 )
 
         backFaceIndices =
-            [ 2, 1, 0 ]
+            ( 2, 1, 0 )
 
         toRightTriangles rightTriangle =
             List.map
@@ -124,9 +155,9 @@ initFaceNormal =
                 )
 
         -- TODO: test the public api of Convex.init instead
-        legacyInitFaceNormal : List Int -> Array Vec3 -> Vec3
+        legacyInitFaceNormal : ( Int, Int, Int ) -> Array Vec3 -> Vec3
         legacyInitFaceNormal indices vertices =
-            Convex.init [ indices ] vertices
+            Convex.fromTriangularMesh [ indices ] vertices
                 |> .faces
                 |> List.head
                 |> Maybe.map .normal
@@ -140,7 +171,7 @@ initFaceNormal =
                             List.map
                                 (\{ vertices } ->
                                     legacyInitFaceNormal
-                                        (List.range 0 (List.length vertices - 1))
+                                        ( 0, 1, 2 )
                                         (Array.fromList (List.reverse vertices))
                                 )
                                 faces

--- a/tests/ConvexTest.elm
+++ b/tests/ConvexTest.elm
@@ -2,8 +2,10 @@ module ConvexTest exposing
     ( addFaceEdges
     , boxUniqueEdges
     , extendContour
+    , inertia
     , initFaceNormal
     , initUniqueEdges
+    , volume
     )
 
 import Array exposing (Array)
@@ -14,6 +16,26 @@ import Internal.Const as Const
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Shapes.Convex as Convex exposing (Convex)
 import Test exposing (Test, describe, test)
+
+
+inertia : Test
+inertia =
+    describe "inertia"
+        [ test "inertia of a Convex.fromBlock is the same as Convex.fromTriangularMesh" <|
+            \_ ->
+                (Fixtures.Convex.cube 2).inertia
+                    |> Expect.mat3 (Convex.fromBlock 2 2 2).inertia
+        ]
+
+
+volume : Test
+volume =
+    describe "volume"
+        [ test "volume of a Convex.fromBlock is the same as Convex.fromTriangularMesh" <|
+            \_ ->
+                (Fixtures.Convex.cube 2).volume
+                    |> Expect.equal (Convex.fromBlock 2 2 2).volume
+        ]
 
 
 extendContour : Test
@@ -220,21 +242,6 @@ initFaceNormal =
                     |> List.map (legacyInitFaceNormal backFaceIndices)
                     |> Expect.vec3s zAntiNormalRingSequence
         ]
-
-
-listRingRotate : Int -> List a -> List a
-listRingRotate offset ring =
-    -- This brute force implementation doubles the list and uses
-    -- modulus indexing to ensure enough elements to carve out the
-    -- desired slice at any non-negative offset.
-    let
-        resultLength =
-            List.length ring
-    in
-    ring
-        ++ ring
-        |> List.drop (modBy resultLength offset)
-        |> List.take resultLength
 
 
 initUniqueEdges : Test
@@ -467,6 +474,22 @@ boxUniqueEdges =
 
 
 -- Test helper functions
+
+
+{-| This brute force implementation doubles the list and uses
+modulus indexing to ensure enough elements to carve out the
+desired slice at any non-negative offset.
+-}
+listRingRotate : Int -> List a -> List a
+listRingRotate offset ring =
+    let
+        resultLength =
+            List.length ring
+    in
+    ring
+        ++ ring
+        |> List.drop (modBy resultLength offset)
+        |> List.take resultLength
 
 
 {-| Provide convenient test access to initUniqueEdges based on the faces and

--- a/tests/Extra/Expect.elm
+++ b/tests/Extra/Expect.elm
@@ -1,10 +1,18 @@
-module Extra.Expect exposing (contacts, frame3d, mat3, vec3, vec3s)
+module Extra.Expect exposing
+    ( contacts
+    , frame3d
+    , mat3
+    , transform3d
+    , vec3
+    , vec3s
+    )
 
 import Direction3d
 import Expect exposing (Expectation, FloatingPointTolerance(..))
 import Frame3d exposing (Frame3d)
 import Internal.Contact exposing (Contact)
 import Internal.Matrix3 exposing (Mat3)
+import Internal.Transform3d as Transform3d exposing (Transform3d)
 import Internal.Vector3 exposing (Vec3)
 import Point3d
 
@@ -35,6 +43,14 @@ mat3 =
         (List.map (Tuple.pair (Expect.within tolerance))
             [ .m11, .m21, .m31, .m12, .m22, .m32, .m13, .m23, .m33 ]
         )
+
+
+transform3d : Transform3d coords define -> Transform3d coords define -> Expectation
+transform3d transform =
+    Expect.all
+        [ \subj -> vec3 (Transform3d.originPoint transform) (Transform3d.originPoint subj)
+        , \subj -> mat3 (Transform3d.orientation transform) (Transform3d.orientation subj)
+        ]
 
 
 frame3d : Frame3d units coords define -> Frame3d units coords define -> Expectation

--- a/tests/Fixtures/Convex.elm
+++ b/tests/Fixtures/Convex.elm
@@ -1,6 +1,7 @@
 module Fixtures.Convex exposing
     ( askewSquarePyramid
-    , cube
+    , block
+    , blockOfTetrahedrons
     , nonSquareQuadPyramid
     , octoHull
     , squarePyramid
@@ -8,6 +9,7 @@ module Fixtures.Convex exposing
 
 import Array
 import Internal.Const as Const
+import Internal.Transform3d as Transform3d exposing (Transform3d)
 import Shapes.Convex as Convex exposing (Convex)
 
 
@@ -15,11 +17,20 @@ import Shapes.Convex as Convex exposing (Convex)
 -- Test data generators
 
 
-cube : Float -> Convex.Convex
-cube size =
+block : Transform3d coord define -> Float -> Float -> Float -> Convex.Convex
+block transform sizeX sizeY sizeZ =
     let
-        halfExtent =
-            size / 2
+        halfExtentX =
+            sizeX / 2
+
+        halfExtentY =
+            sizeY / 2
+
+        halfExtentZ =
+            sizeZ / 2
+
+        t p =
+            Transform3d.pointPlaceIn transform p
     in
     Convex.fromTriangularMesh
         [ ( 1, 7, 5 )
@@ -36,16 +47,52 @@ cube size =
         , ( 3, 2, 1 )
         ]
         (Array.fromList
-            [ { x = halfExtent, y = -halfExtent, z = -halfExtent }
-            , { x = halfExtent, y = halfExtent, z = -halfExtent }
-            , { x = -halfExtent, y = halfExtent, z = -halfExtent }
-            , { x = -halfExtent, y = -halfExtent, z = -halfExtent }
-            , { x = halfExtent, y = -halfExtent, z = halfExtent }
-            , { x = halfExtent, y = halfExtent, z = halfExtent }
-            , { x = -halfExtent, y = -halfExtent, z = halfExtent }
-            , { x = -halfExtent, y = halfExtent, z = halfExtent }
+            [ t { x = halfExtentX, y = -halfExtentY, z = -halfExtentZ }
+            , t { x = halfExtentX, y = halfExtentY, z = -halfExtentZ }
+            , t { x = -halfExtentX, y = halfExtentY, z = -halfExtentZ }
+            , t { x = -halfExtentX, y = -halfExtentY, z = -halfExtentZ }
+            , t { x = halfExtentX, y = -halfExtentY, z = halfExtentZ }
+            , t { x = halfExtentX, y = halfExtentY, z = halfExtentZ }
+            , t { x = -halfExtentX, y = -halfExtentY, z = halfExtentZ }
+            , t { x = -halfExtentX, y = halfExtentY, z = halfExtentZ }
             ]
         )
+
+
+blockOfTetrahedrons : Float -> Float -> Float -> List Convex.Convex
+blockOfTetrahedrons sizeX sizeY sizeZ =
+    let
+        lX =
+            sizeX / 2
+
+        lY =
+            sizeY / 2
+
+        lZ =
+            sizeZ / 2
+
+        p0 =
+            { x = 0, y = 0, z = 0 }
+    in
+    List.map
+        (\( p1, p2, p3 ) ->
+            Convex.fromTriangularMesh
+                [ ( 1, 0, 2 ), ( 2, 0, 3 ), ( 3, 0, 1 ), ( 3, 1, 2 ) ]
+                (Array.fromList [ p0, p1, p2, p3 ])
+        )
+        [ ( { x = lX, y = lY, z = -lZ }, { x = -lX, y = lY, z = lZ }, { x = lX, y = lY, z = lZ } )
+        , ( { x = lX, y = lY, z = -lZ }, { x = -lX, y = lY, z = -lZ }, { x = -lX, y = lY, z = lZ } )
+        , ( { x = lX, y = -lY, z = lZ }, { x = -lX, y = lY, z = lZ }, { x = -lX, y = -lY, z = lZ } )
+        , ( { x = lX, y = -lY, z = lZ }, { x = lX, y = lY, z = lZ }, { x = -lX, y = lY, z = lZ } )
+        , ( { x = -lX, y = -lY, z = lZ }, { x = -lX, y = lY, z = -lZ }, { x = -lX, y = -lY, z = -lZ } )
+        , ( { x = -lX, y = -lY, z = lZ }, { x = -lX, y = lY, z = lZ }, { x = -lX, y = lY, z = -lZ } )
+        , ( { x = -lX, y = -lY, z = -lZ }, { x = lX, y = -lY, z = lZ }, { x = -lX, y = -lY, z = lZ } )
+        , ( { x = -lX, y = -lY, z = -lZ }, { x = lX, y = -lY, z = -lZ }, { x = lX, y = -lY, z = lZ } )
+        , ( { x = lX, y = -lY, z = -lZ }, { x = lX, y = lY, z = lZ }, { x = lX, y = -lY, z = lZ } )
+        , ( { x = lX, y = -lY, z = -lZ }, { x = lX, y = lY, z = -lZ }, { x = lX, y = lY, z = lZ } )
+        , ( { x = -lX, y = -lY, z = -lZ }, { x = lX, y = lY, z = -lZ }, { x = lX, y = -lY, z = -lZ } )
+        , ( { x = -lX, y = -lY, z = -lZ }, { x = -lX, y = lY, z = -lZ }, { x = lX, y = lY, z = -lZ } )
+        ]
 
 
 octoHull : Float -> Convex.Convex

--- a/tests/Fixtures/Convex.elm
+++ b/tests/Fixtures/Convex.elm
@@ -1,18 +1,12 @@
 module Fixtures.Convex exposing
     ( askewSquarePyramid
-    , boxVertexIndices
     , nonSquareQuadPyramid
     , octoHull
-    , octoVertexIndices
-    , octoVertices
-    , originalOctoHull
-    , squareLikePyramid
     , squarePyramid
     )
 
-import Array exposing (Array)
+import Array
 import Internal.Const as Const
-import Internal.Vector3 exposing (Vec3)
 import Shapes.Convex as Convex exposing (Convex)
 
 
@@ -20,52 +14,27 @@ import Shapes.Convex as Convex exposing (Convex)
 -- Test data generators
 
 
-boxVertexIndices : List (List Int)
-boxVertexIndices =
-    [ [ 3, 2, 1, 0 ]
-    , [ 4, 5, 6, 7 ]
-    , [ 5, 4, 0, 1 ]
-    , [ 2, 3, 7, 6 ]
-    , [ 0, 4, 7, 3 ]
-    , [ 1, 2, 6, 5 ]
-    ]
-
-
-octoVertices : Float -> Array Vec3
-octoVertices halfExtent =
-    Array.fromList
-        [ { x = 0, y = 0, z = halfExtent }
-        , { x = 0, y = halfExtent, z = 0 }
-        , { x = halfExtent, y = 0, z = 0 }
-        , { x = -halfExtent, y = 0, z = 0 }
-        , { x = 0, y = 0, z = -halfExtent }
-        , { x = 0, y = -halfExtent, z = 0 }
-        ]
-
-
 octoHull : Float -> Convex.Convex
 octoHull halfExtent =
-    octoVertices halfExtent
-        |> Convex.fromTriangularMesh octoVertexIndices
-
-
-originalOctoHull : Float -> Convex.Convex
-originalOctoHull halfExtent =
-    octoVertices halfExtent
-        |> Convex.fromTriangularMesh octoVertexIndices
-
-
-octoVertexIndices : List ( Int, Int, Int )
-octoVertexIndices =
-    [ ( 2, 1, 0 )
-    , ( 0, 5, 2 )
-    , ( 1, 2, 4 )
-    , ( 3, 0, 1 )
-    , ( 2, 5, 4 )
-    , ( 4, 3, 1 )
-    , ( 5, 0, 3 )
-    , ( 3, 4, 5 )
-    ]
+    Convex.fromTriangularMesh
+        [ ( 2, 1, 0 )
+        , ( 0, 5, 2 )
+        , ( 1, 2, 4 )
+        , ( 3, 0, 1 )
+        , ( 2, 5, 4 )
+        , ( 4, 3, 1 )
+        , ( 5, 0, 3 )
+        , ( 3, 4, 5 )
+        ]
+        (Array.fromList
+            [ { x = 0, y = 0, z = halfExtent }
+            , { x = 0, y = halfExtent, z = 0 }
+            , { x = halfExtent, y = 0, z = 0 }
+            , { x = -halfExtent, y = 0, z = 0 }
+            , { x = 0, y = 0, z = -halfExtent }
+            , { x = 0, y = -halfExtent, z = 0 }
+            ]
+        )
 
 
 squarePyramid : Convex
@@ -106,7 +75,7 @@ squareLikePyramid epsilon =
 
         vertexIndices =
             [ ( 3, 2, 1 )
-            , ( 2, 1, 0 )
+            , ( 3, 1, 0 )
             , ( 0, 1, 4 )
             , ( 1, 2, 4 )
             , ( 2, 3, 4 )

--- a/tests/Fixtures/Convex.elm
+++ b/tests/Fixtures/Convex.elm
@@ -1,5 +1,6 @@
 module Fixtures.Convex exposing
     ( askewSquarePyramid
+    , cube
     , nonSquareQuadPyramid
     , octoHull
     , squarePyramid
@@ -12,6 +13,39 @@ import Shapes.Convex as Convex exposing (Convex)
 
 
 -- Test data generators
+
+
+cube : Float -> Convex.Convex
+cube size =
+    let
+        halfExtent =
+            size / 2
+    in
+    Convex.fromTriangularMesh
+        [ ( 1, 7, 5 )
+        , ( 1, 2, 7 )
+        , ( 4, 7, 6 )
+        , ( 4, 5, 7 )
+        , ( 6, 2, 3 )
+        , ( 6, 7, 2 )
+        , ( 3, 4, 6 )
+        , ( 3, 0, 4 )
+        , ( 0, 5, 4 )
+        , ( 0, 1, 5 )
+        , ( 3, 1, 0 )
+        , ( 3, 2, 1 )
+        ]
+        (Array.fromList
+            [ { x = halfExtent, y = -halfExtent, z = -halfExtent }
+            , { x = halfExtent, y = halfExtent, z = -halfExtent }
+            , { x = -halfExtent, y = halfExtent, z = -halfExtent }
+            , { x = -halfExtent, y = -halfExtent, z = -halfExtent }
+            , { x = halfExtent, y = -halfExtent, z = halfExtent }
+            , { x = halfExtent, y = halfExtent, z = halfExtent }
+            , { x = -halfExtent, y = -halfExtent, z = halfExtent }
+            , { x = -halfExtent, y = halfExtent, z = halfExtent }
+            ]
+        )
 
 
 octoHull : Float -> Convex.Convex

--- a/tests/Fixtures/Convex.elm
+++ b/tests/Fixtures/Convex.elm
@@ -46,25 +46,25 @@ octoVertices halfExtent =
 octoHull : Float -> Convex.Convex
 octoHull halfExtent =
     octoVertices halfExtent
-        |> Convex.init octoVertexIndices
+        |> Convex.fromTriangularMesh octoVertexIndices
 
 
 originalOctoHull : Float -> Convex.Convex
 originalOctoHull halfExtent =
     octoVertices halfExtent
-        |> Convex.init octoVertexIndices
+        |> Convex.fromTriangularMesh octoVertexIndices
 
 
-octoVertexIndices : List (List Int)
+octoVertexIndices : List ( Int, Int, Int )
 octoVertexIndices =
-    [ [ 2, 1, 0 ]
-    , [ 0, 5, 2 ]
-    , [ 1, 2, 4 ]
-    , [ 3, 0, 1 ]
-    , [ 2, 5, 4 ]
-    , [ 4, 3, 1 ]
-    , [ 5, 0, 3 ]
-    , [ 3, 4, 5 ]
+    [ ( 2, 1, 0 )
+    , ( 0, 5, 2 )
+    , ( 1, 2, 4 )
+    , ( 3, 0, 1 )
+    , ( 2, 5, 4 )
+    , ( 4, 3, 1 )
+    , ( 5, 0, 3 )
+    , ( 3, 4, 5 )
     ]
 
 
@@ -104,12 +104,13 @@ squareLikePyramid epsilon =
         zOffset =
             z * (0.5 ^ (1.0 / 3.0))
 
-        faces =
-            [ [ 3, 2, 1, 0 ]
-            , [ 0, 1, 4 ]
-            , [ 1, 2, 4 ]
-            , [ 2, 3, 4 ]
-            , [ 3, 0, 4 ]
+        vertexIndices =
+            [ ( 3, 2, 1 )
+            , ( 2, 1, 0 )
+            , ( 0, 1, 4 )
+            , ( 1, 2, 4 )
+            , ( 2, 3, 4 )
+            , ( 3, 0, 4 )
             ]
 
         vertices =
@@ -125,4 +126,4 @@ squareLikePyramid epsilon =
                 , { x = 0, y = 0, z = z - zOffset }
                 ]
     in
-    Convex.init faces vertices
+    Convex.fromTriangularMesh vertexIndices vertices

--- a/tests/Fixtures/NarrowPhase.elm
+++ b/tests/Fixtures/NarrowPhase.elm
@@ -9,8 +9,11 @@ import Internal.Vector3 as Vec3 exposing (Vec3)
 
 
 sphereContactBoxPositions : Vec3 -> Float -> Float -> List ( Vec3, List Contact )
-sphereContactBoxPositions center radius boxHalfExtent =
+sphereContactBoxPositions center radius boxSize =
     let
+        boxHalfExtent =
+            boxSize / 2
+
         delta =
             3 * Const.precision
 


### PR DESCRIPTION
This PR implements #91 by adding the new function to the `Physics.Shape` module:

`unsafeConvex : TriangularMesh (Point3d Meters BodyCoordinates) -> Shape`
 
![convex](https://user-images.githubusercontent.com/43472/91758237-f5a1ca00-ebcf-11ea-92bb-a4ca8e617444.gif)


TODO:

- [x] join coplanar adjacent faces (should fix the existing tests)
- [x] improve the tests and add more tests for things like inertia
- [ ] document `unsafeConvex`



