### PR TITLE
Add cylinder shape

### DIFF
--- a/examples/Randomize.elm
+++ b/examples/Randomize.elm
@@ -16,6 +16,7 @@ import Common.Fps as Fps
 import Common.Meshes as Meshes exposing (Meshes)
 import Common.Scene as Scene
 import Common.Settings as Settings exposing (Settings, SettingsMsg, settings)
+import Cylinder3d
 import Direction3d
 import Duration
 import Frame3d
@@ -156,6 +157,13 @@ initialWorld =
                 |> Body.moveTo (Point3d.meters 0.5 0 8)
             )
         |> World.add
+            (cylinder
+                |> Body.rotateAround
+                    (Axis3d.through Point3d.origin (Direction3d.unsafe { x = 0.7071, y = 0.7071, z = 0 }))
+                    (Angle.radians (pi / 2))
+                |> Body.moveTo (Point3d.meters 0.5 0 11)
+            )
+        |> World.add
             (compound
                 |> Body.rotateAround
                     (Axis3d.through Point3d.origin (Direction3d.unsafe { x = 0.7071, y = 0.7071, z = 0 }))
@@ -206,6 +214,22 @@ sphere =
         |> Body.withBehavior (Body.dynamic (Mass.kilograms 5))
 
 
+cylinder : Body Meshes
+cylinder =
+    let
+        length =
+            Length.meters 2
+
+        radius =
+            Length.meters 0.5
+    in
+    Body.cylinder
+        12
+        (Cylinder3d.centeredOn Point3d.origin Direction3d.z { radius = radius, length = length })
+        (Meshes.fromTriangles (Meshes.cylinder 12 radius length))
+        |> Body.withBehavior (Body.dynamic (Mass.kilograms 5))
+
+
 {-| A compound body made of three boxes
 -}
 compound : Body Meshes
@@ -245,6 +269,9 @@ randomBody =
                 1 ->
                     sphere
 
+                2 ->
+                    cylinder
+
                 _ ->
                     compound
             )
@@ -257,4 +284,4 @@ randomBody =
         (Random.float -1 1)
         (Random.float -1 1)
         (Random.float -1 1)
-        (Random.int 0 2)
+        (Random.int 0 3)

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -21,7 +21,7 @@
             "ianmackenzie/elm-geometry": "3.6.0",
             "ianmackenzie/elm-geometry-linear-algebra-interop": "2.0.2",
             "ianmackenzie/elm-triangular-mesh": "1.0.4",
-            "ianmackenzie/elm-units": "2.6.0",
+            "ianmackenzie/elm-units": "2.7.0",
             "w0rm/elm-obj-file": "1.0.0"
         },
         "indirect": {

--- a/src/Internal/Matrix3.elm
+++ b/src/Internal/Matrix3.elm
@@ -1,6 +1,7 @@
 module Internal.Matrix3 exposing
     ( Mat3
     , add
+    , cylinderInertia
     , inverse
     , mul
     , pointInertia
@@ -197,6 +198,24 @@ sphereInertia m radius =
     , m13 = 0
     , m23 = 0
     , m33 = i
+    }
+
+
+cylinderInertia : Float -> Float -> Float -> Mat3
+cylinderInertia m radius height =
+    let
+        a =
+            (m * (3 * radius ^ 2 + height ^ 2)) / 12
+    in
+    { m11 = a
+    , m21 = 0
+    , m31 = 0
+    , m12 = 0
+    , m22 = a
+    , m32 = 0
+    , m13 = 0
+    , m23 = 0
+    , m33 = (m * radius ^ 2) / 2
     }
 
 

--- a/src/Physics/Body.elm
+++ b/src/Physics/Body.elm
@@ -85,6 +85,7 @@ The supported bodies are:
   - [block](#block),
   - [plane](#plane),
   - [sphere](#sphere),
+  - [cylinder](#cylinder),
   - [particle](#particle).
 
 For complex bodies check [compound](#compound).
@@ -112,6 +113,21 @@ block block3d =
     compound [ Shape.block block3d ]
 
 
+{-| A cylinder is created from elm-geometry [Cylinder3d](https://package.elm-lang.org/packages/ianmackenzie/elm-geometry/latest/Cylinder3d).
+To create a vertical cylinder, centered at the origin of
+the body, call this:
+
+    cylinderBody =
+        cylinder
+            12
+            (Cylinder3d.centeredOn
+                Point3d.origin
+                Direction3d.z
+                { radius = Length.meter, length = Length.meter }
+            )
+            data
+
+-}
 cylinder : Int -> Cylinder3d Meters BodyCoordinates -> data -> Body data
 cylinder detail cylinder3d =
     compound [ Shape.cylinder detail cylinder3d ]

--- a/src/Physics/Body.elm
+++ b/src/Physics/Body.elm
@@ -6,6 +6,7 @@ module Physics.Body exposing
     , data, withData
     , applyForce, applyImpulse
     , withMaterial, compound, withDamping
+    , cylinder
     )
 
 {-|
@@ -48,6 +49,7 @@ import Angle exposing (Angle)
 import AngularSpeed exposing (RadiansPerSecond)
 import Axis3d exposing (Axis3d)
 import Block3d exposing (Block3d)
+import Cylinder3d exposing (Cylinder3d)
 import Direction3d exposing (Direction3d)
 import Duration exposing (Seconds)
 import Force exposing (Newtons)
@@ -108,6 +110,11 @@ the body, call this:
 block : Block3d Meters BodyCoordinates -> data -> Body data
 block block3d =
     compound [ Shape.block block3d ]
+
+
+cylinder : Int -> Cylinder3d Meters BodyCoordinates -> data -> Body data
+cylinder detail cylinder3d =
+    compound [ Shape.cylinder detail cylinder3d ]
 
 
 {-| A plane with the normal that points

--- a/src/Physics/Shape.elm
+++ b/src/Physics/Shape.elm
@@ -177,11 +177,11 @@ cylinder detail cylinder3d =
                     )
     in
     { faces =
-        { vertices = List.reverse <| cap bottom, normal = { x = 0, y = 0, z = -1 } }
-            :: { vertices = cap top, normal = { x = 0, y = 0, z = 1 } }
+        { vertices = cap bottom, normal = { x = 0, y = 0, z = -1 } }
+            :: { vertices = List.reverse <| cap top, normal = { x = 0, y = 0, z = 1 } }
             :: List.map
                 (\face ->
-                    { vertices = List.reverse [ face.v0, face.v1, face.v2, face.v3 ]
+                    { vertices = [ face.v0, face.v1, face.v2, face.v3 ]
                     , normal = face.normal
                     }
                 )

--- a/src/Physics/Shape.elm
+++ b/src/Physics/Shape.elm
@@ -18,6 +18,7 @@ import Internal.Transform3d as Transform3d
 import Length exposing (Meters)
 import Physics.Coordinates exposing (BodyCoordinates)
 import Point3d exposing (Point3d)
+import Quantity
 import Shapes.Convex as Convex
 import Shapes.Sphere as Sphere
 import Sphere3d exposing (Sphere3d)
@@ -127,7 +128,10 @@ cylinder detail cylinder3d =
                 (Direction3d.unwrap b)
                 (Cylinder3d.axialDirection cylinder3d |> Direction3d.toVector |> Vector3d.unwrap)
     in
-    Convex.fromCylinder detail cylinder3d
+    Convex.fromCylinder
+        detail
+        (Cylinder3d.radius cylinder3d |> Quantity.unwrap)
+        (Cylinder3d.length cylinder3d |> Quantity.unwrap)
         |> Convex.placeIn transform3d
         |> Internal.Convex
         |> Protected

--- a/src/Physics/Shape.elm
+++ b/src/Physics/Shape.elm
@@ -1,4 +1,7 @@
-module Physics.Shape exposing (Shape, block, sphere, unsafeConvex)
+module Physics.Shape exposing
+    ( Shape, block, sphere, unsafeConvex
+    , cylinder
+    )
 
 {-|
 
@@ -6,18 +9,23 @@ module Physics.Shape exposing (Shape, block, sphere, unsafeConvex)
 
 -}
 
+import Angle
 import Block3d exposing (Block3d)
+import Cylinder3d exposing (Cylinder3d)
 import Direction3d
 import Frame3d
+import Internal.Matrix3
 import Internal.Shape as Internal exposing (Protected(..))
 import Internal.Transform3d as Transform3d
 import Length exposing (Meters)
 import Physics.Coordinates exposing (BodyCoordinates)
 import Point3d exposing (Point3d)
+import Quantity exposing (Quantity(..))
 import Shapes.Convex as Convex
 import Shapes.Sphere as Sphere
 import Sphere3d exposing (Sphere3d)
 import TriangularMesh exposing (TriangularMesh)
+import Vector3d
 
 
 {-| Shapes are only needed for creating [compound](Physics-Body#compound) bodies.
@@ -98,6 +106,108 @@ sphere sphere3d =
                 |> Sphere.placeIn (Transform3d.atPoint origin)
             )
         )
+
+
+{-|
+
+    cylinder 12 myCylinder -- A cylinder with 12 faces (not counting the top and bottom face)
+
+    cylinder 2 myCylinder -- Too few faces so it has 3 faces instead
+
+-}
+cylinder : Int -> Cylinder3d Meters BodyCoordinates -> Shape
+cylinder detail cylinder3d =
+    let
+        detail_ =
+            max 3 detail
+
+        ( a, b ) =
+            Cylinder3d.axialDirection cylinder3d |> Direction3d.perpendicularBasis
+
+        top =
+            Cylinder3d.length cylinder3d |> Quantity.unwrap |> (*) 0.5
+
+        bottom =
+            Cylinder3d.length cylinder3d |> Quantity.unwrap |> (*) -0.5
+
+        radius =
+            Cylinder3d.radius cylinder3d |> Quantity.unwrap
+
+        faces =
+            List.range 0 (detail_ - 1)
+                |> List.map
+                    (\value ->
+                        let
+                            r0 =
+                                2 * pi * (toFloat value - 0.5) / toFloat detail_
+
+                            r1 =
+                                2 * pi * toFloat value / toFloat detail_
+
+                            r2 =
+                                2 * pi * (toFloat value + 0.5) / toFloat detail_
+                        in
+                        { normal = { x = sin r1, y = cos r1, z = 0 }
+                        , v0 = { x = sin r0 * radius, y = cos r0 * radius, z = top }
+                        , v1 = { x = sin r2 * radius, y = cos r2 * radius, z = top }
+                        , v2 = { x = sin r2 * radius, y = cos r2 * radius, z = bottom }
+                        , v3 = { x = sin r0 * radius, y = cos r0 * radius, z = bottom }
+                        }
+                    )
+
+        transform3d =
+            Transform3d.fromOriginAndBasis
+                (Cylinder3d.centerPoint cylinder3d |> Point3d.unwrap)
+                (Direction3d.unwrap a)
+                (Direction3d.unwrap b)
+                (Cylinder3d.axialDirection cylinder3d |> Direction3d.toVector |> Vector3d.unwrap)
+
+        volume =
+            Cylinder3d.volume cylinder3d |> Quantity.unwrap
+
+        cap z =
+            List.range 0 (detail_ - 1)
+                |> List.map
+                    (\value ->
+                        let
+                            r0 =
+                                2 * pi * (toFloat value - 0.5) / toFloat detail_
+                        in
+                        { x = sin r0 * radius, y = cos r0 * radius, z = z }
+                    )
+    in
+    { faces =
+        { vertices = List.reverse <| cap bottom, normal = { x = 0, y = 0, z = -1 } }
+            :: { vertices = cap top, normal = { x = 0, y = 0, z = 1 } }
+            :: List.map
+                (\face ->
+                    { vertices = List.reverse [ face.v0, face.v1, face.v2, face.v3 ]
+                    , normal = face.normal
+                    }
+                )
+                faces
+    , vertices = List.concatMap (\face -> [ face.v1, face.v2 ]) faces
+    , uniqueEdges = List.concatMap (\face -> [ face.v0, face.v1, face.v2, face.v3, face.v1, face.v2 ]) faces
+    , uniqueNormals =
+        { x = 0, y = 0, z = -1 }
+            :: { x = 0, y = 0, z = 1 }
+            :: (if modBy 2 detail_ == 0 then
+                    List.map .normal faces |> List.take (detail_ // 2)
+
+                else
+                    List.map .normal faces
+               )
+    , position = { x = 0, y = 0, z = 0 }
+    , inertia =
+        Internal.Matrix3.cylinderInertia
+            volume
+            radius
+            (Cylinder3d.length cylinder3d |> Quantity.unwrap)
+    , volume = volume
+    }
+        |> Convex.placeIn transform3d
+        |> Internal.Convex
+        |> Protected
 
 
 {-| Create a shape from the triangular mesh. This is useful if you want

--- a/src/Physics/Shape.elm
+++ b/src/Physics/Shape.elm
@@ -9,18 +9,15 @@ module Physics.Shape exposing
 
 -}
 
-import Angle
 import Block3d exposing (Block3d)
 import Cylinder3d exposing (Cylinder3d)
 import Direction3d
 import Frame3d
-import Internal.Matrix3
 import Internal.Shape as Internal exposing (Protected(..))
 import Internal.Transform3d as Transform3d
 import Length exposing (Meters)
 import Physics.Coordinates exposing (BodyCoordinates)
 import Point3d exposing (Point3d)
-import Quantity exposing (Quantity(..))
 import Shapes.Convex as Convex
 import Shapes.Sphere as Sphere
 import Sphere3d exposing (Sphere3d)
@@ -120,42 +117,8 @@ Note that it's more efficient to simulate cylinders with an even number of faces
 cylinder : Int -> Cylinder3d Meters BodyCoordinates -> Shape
 cylinder detail cylinder3d =
     let
-        detail_ =
-            max 3 detail
-
         ( a, b ) =
             Cylinder3d.axialDirection cylinder3d |> Direction3d.perpendicularBasis
-
-        top =
-            Cylinder3d.length cylinder3d |> Quantity.unwrap |> (*) 0.5
-
-        bottom =
-            Cylinder3d.length cylinder3d |> Quantity.unwrap |> (*) -0.5
-
-        radius =
-            Cylinder3d.radius cylinder3d |> Quantity.unwrap
-
-        faces =
-            List.range 0 (detail_ - 1)
-                |> List.map
-                    (\value ->
-                        let
-                            r0 =
-                                2 * pi * (toFloat value - 0.5) / toFloat detail_
-
-                            r1 =
-                                2 * pi * toFloat value / toFloat detail_
-
-                            r2 =
-                                2 * pi * (toFloat value + 0.5) / toFloat detail_
-                        in
-                        { normal = { x = sin r1, y = cos r1, z = 0 }
-                        , v0 = { x = sin r0 * radius, y = cos r0 * radius, z = top }
-                        , v1 = { x = sin r2 * radius, y = cos r2 * radius, z = top }
-                        , v2 = { x = sin r2 * radius, y = cos r2 * radius, z = bottom }
-                        , v3 = { x = sin r0 * radius, y = cos r0 * radius, z = bottom }
-                        }
-                    )
 
         transform3d =
             Transform3d.fromOriginAndBasis
@@ -163,50 +126,8 @@ cylinder detail cylinder3d =
                 (Direction3d.unwrap a)
                 (Direction3d.unwrap b)
                 (Cylinder3d.axialDirection cylinder3d |> Direction3d.toVector |> Vector3d.unwrap)
-
-        volume =
-            Cylinder3d.volume cylinder3d |> Quantity.unwrap
-
-        cap z =
-            List.range 0 (detail_ - 1)
-                |> List.map
-                    (\value ->
-                        let
-                            r0 =
-                                2 * pi * (toFloat value - 0.5) / toFloat detail_
-                        in
-                        { x = sin r0 * radius, y = cos r0 * radius, z = z }
-                    )
     in
-    { faces =
-        { vertices = cap bottom, normal = { x = 0, y = 0, z = -1 } }
-            :: { vertices = List.reverse <| cap top, normal = { x = 0, y = 0, z = 1 } }
-            :: List.map
-                (\face ->
-                    { vertices = [ face.v0, face.v1, face.v2, face.v3 ]
-                    , normal = face.normal
-                    }
-                )
-                faces
-    , vertices = List.concatMap (\face -> [ face.v1, face.v2 ]) faces
-    , uniqueEdges = List.concatMap (\face -> [ face.v0, face.v1, face.v2, face.v3, face.v1, face.v2 ]) faces
-    , uniqueNormals =
-        { x = 0, y = 0, z = -1 }
-            :: { x = 0, y = 0, z = 1 }
-            :: (if modBy 2 detail_ == 0 then
-                    List.map .normal faces |> List.take (detail_ // 2)
-
-                else
-                    List.map .normal faces
-               )
-    , position = { x = 0, y = 0, z = 0 }
-    , inertia =
-        Internal.Matrix3.cylinderInertia
-            volume
-            radius
-            (Cylinder3d.length cylinder3d |> Quantity.unwrap)
-    , volume = volume
-    }
+    Convex.fromCylinder detail cylinder3d
         |> Convex.placeIn transform3d
         |> Internal.Convex
         |> Protected

--- a/src/Physics/Shape.elm
+++ b/src/Physics/Shape.elm
@@ -114,6 +114,8 @@ sphere sphere3d =
 
     cylinder 2 myCylinder -- Too few faces so it has 3 faces instead
 
+Note that it's more efficient to simulate cylinders with an even number of faces than an odd number of faces.
+
 -}
 cylinder : Int -> Cylinder3d Meters BodyCoordinates -> Shape
 cylinder detail cylinder3d =

--- a/src/Shapes/Convex.elm
+++ b/src/Shapes/Convex.elm
@@ -14,13 +14,10 @@ module Shapes.Convex exposing
     )
 
 import Array exposing (Array)
-import Cylinder3d exposing (Cylinder3d)
 import Dict exposing (Dict)
-import Direction3d
 import Internal.Matrix3 as Mat3 exposing (Mat3)
 import Internal.Transform3d as Transform3d exposing (Transform3d)
 import Internal.Vector3 as Vec3 exposing (Vec3)
-import Quantity
 import Set exposing (Set)
 
 
@@ -480,20 +477,17 @@ fromBlock sizeX sizeY sizeZ =
     }
 
 
-fromCylinder : Int -> Cylinder3d units coordinates -> Convex
-fromCylinder detail cylinder3d =
+fromCylinder : Int -> Float -> Float -> Convex
+fromCylinder detail radius length =
     let
         detail_ =
             max 3 detail
 
         top =
-            Cylinder3d.length cylinder3d |> Quantity.unwrap |> (*) 0.5
+            length * 0.5
 
         bottom =
-            Cylinder3d.length cylinder3d |> Quantity.unwrap |> (*) -0.5
-
-        radius =
-            Cylinder3d.radius cylinder3d |> Quantity.unwrap
+            length * -0.5
 
         faces =
             List.range 0 (detail_ - 1)
@@ -518,7 +512,7 @@ fromCylinder detail cylinder3d =
                     )
 
         volume =
-            Cylinder3d.volume cylinder3d |> Quantity.unwrap
+            2 * pi * length * radius ^ 2
 
         cap z =
             List.range 0 (detail_ - 1)
@@ -565,7 +559,7 @@ fromCylinder detail cylinder3d =
         Mat3.cylinderInertia
             volume
             radius
-            (Cylinder3d.length cylinder3d |> Quantity.unwrap)
+            length
     , volume = volume
     }
 

--- a/src/Shapes/Convex.elm
+++ b/src/Shapes/Convex.elm
@@ -553,8 +553,7 @@ fromCylinder detail cylinder3d =
                     faces
                 )
     , uniqueNormals =
-        { x = 0, y = 0, z = -1 }
-            :: { x = 0, y = 0, z = 1 }
+        { x = 0, y = 0, z = 1 }
             :: (if modBy 2 detail_ == 0 then
                     List.take (detail_ // 2) faces |> List.map .normal
 

--- a/src/Shapes/Convex.elm
+++ b/src/Shapes/Convex.elm
@@ -6,6 +6,7 @@ module Shapes.Convex exposing
     , extendContour
     , foldFaceEdges
     , fromBlock
+    , fromCylinder
     , fromTriangularMesh
     , placeIn
     , placeInWithInertia
@@ -13,10 +14,13 @@ module Shapes.Convex exposing
     )
 
 import Array exposing (Array)
+import Cylinder3d exposing (Cylinder3d)
 import Dict exposing (Dict)
+import Direction3d
 import Internal.Matrix3 as Mat3 exposing (Mat3)
 import Internal.Transform3d as Transform3d exposing (Transform3d)
 import Internal.Vector3 as Vec3 exposing (Vec3)
+import Quantity
 import Set exposing (Set)
 
 
@@ -473,6 +477,97 @@ fromBlock sizeX sizeY sizeZ =
     , volume = volume
     , position = Vec3.zero
     , inertia = inertia
+    }
+
+
+fromCylinder : Int -> Cylinder3d units coordinates -> Convex
+fromCylinder detail cylinder3d =
+    let
+        detail_ =
+            max 3 detail
+
+        top =
+            Cylinder3d.length cylinder3d |> Quantity.unwrap |> (*) 0.5
+
+        bottom =
+            Cylinder3d.length cylinder3d |> Quantity.unwrap |> (*) -0.5
+
+        radius =
+            Cylinder3d.radius cylinder3d |> Quantity.unwrap
+
+        faces =
+            List.range 0 (detail_ - 1)
+                |> List.map
+                    (\value ->
+                        let
+                            r0 =
+                                2 * pi * (toFloat value - 0.5) / toFloat detail_
+
+                            r1 =
+                                2 * pi * toFloat value / toFloat detail_
+
+                            r2 =
+                                2 * pi * (toFloat value + 0.5) / toFloat detail_
+                        in
+                        { normal = { x = sin r1, y = cos r1, z = 0 }
+                        , v0 = { x = sin r0 * radius, y = cos r0 * radius, z = top }
+                        , v1 = { x = sin r2 * radius, y = cos r2 * radius, z = top }
+                        , v2 = { x = sin r2 * radius, y = cos r2 * radius, z = bottom }
+                        , v3 = { x = sin r0 * radius, y = cos r0 * radius, z = bottom }
+                        }
+                    )
+
+        volume =
+            Cylinder3d.volume cylinder3d |> Quantity.unwrap
+
+        cap z =
+            List.range 0 (detail_ - 1)
+                |> List.map
+                    (\value ->
+                        let
+                            r0 =
+                                2 * pi * (toFloat value - 0.5) / toFloat detail_
+                        in
+                        { x = sin r0 * radius, y = cos r0 * radius, z = z }
+                    )
+    in
+    { faces =
+        { vertices = cap bottom, normal = { x = 0, y = 0, z = -1 } }
+            :: { vertices = List.reverse <| cap top, normal = { x = 0, y = 0, z = 1 } }
+            :: List.map
+                (\face ->
+                    { vertices = [ face.v0, face.v1, face.v2, face.v3 ]
+                    , normal = face.normal
+                    }
+                )
+                faces
+    , vertices = List.concatMap (\face -> [ face.v1, face.v2 ]) faces
+    , uniqueEdges =
+        { x = 0, y = 0, z = 1 }
+            -- Rotate normals by 90 degrees to get edge directions
+            :: List.map (\{ normal } -> { x = -normal.y, y = normal.x, z = 0 })
+                (if modBy 2 detail_ == 0 then
+                    List.take (detail_ // 2) faces
+
+                 else
+                    faces
+                )
+    , uniqueNormals =
+        { x = 0, y = 0, z = -1 }
+            :: { x = 0, y = 0, z = 1 }
+            :: (if modBy 2 detail_ == 0 then
+                    List.take (detail_ // 2) faces |> List.map .normal
+
+                else
+                    List.map .normal faces
+               )
+    , position = { x = 0, y = 0, z = 0 }
+    , inertia =
+        Mat3.cylinderInertia
+            volume
+            radius
+            (Cylinder3d.length cylinder3d |> Quantity.unwrap)
+    , volume = volume
     }
 
 


### PR DESCRIPTION
Added `Physics.Shape.cylinder` and `Physics.Body.cylinder`. `Physics.Body.cylinder` takes a `detail` parameter but maybe this can be changed. There was discussion about only having that for `Physics.Shape.cylinder` and using a reasonable default value otherwise.