### PR TITLE
Gauss-arc edge SAT for convex-convex collision

### DIFF
--- a/src/Collision/CapsuleConvex.elm
+++ b/src/Collision/CapsuleConvex.elm
@@ -7,7 +7,7 @@ import Internal.ContactId as ContactId
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Internal.VertexBuffer as VertexBuffer exposing (VertexBuffer)
 import Shapes.Capsule exposing (Capsule)
-import Shapes.Convex as Convex exposing (Convex, Face)
+import Shapes.Convex as Convex exposing (Convex, Edge, Face)
 
 
 {-| `|dot(capsule.axis, separatingAxis)|` below this snaps to the cylinder
@@ -75,7 +75,7 @@ addContacts shapeKey orderContact capsule convex contacts =
             contacts
 
         Just separatingAxis ->
-            case testCapsuleConvexAxis capsule convex separatingAxis of
+            case capsuleOverlap capsule separatingAxis (ConvexConvex.projectConvex separatingAxis convex) of
                 Nothing ->
                     contacts
 
@@ -500,16 +500,16 @@ testConvexNormals : Capsule -> Convex -> Vec3 -> Vec3 -> List Convex.FaceGroup -
 testConvexNormals capsule convex ep1 ep2 groups target dmin =
     case groups of
         [] ->
-            testUniqueEdges capsule convex ep1 ep2 convex.uniqueEdges target dmin
+            testUniqueEdges capsule convex ep1 ep2 [] convex.uniqueEdges target dmin
 
         group :: restGroups ->
             let
                 -- Only the primary normal is needed; the partner's is its
-                -- negation and `testCapsuleConvexAxis` is sign-independent.
+                -- negation and `capsuleOverlap` is sign-independent.
                 normal =
                     Convex.faceGroupNormal group
             in
-            case testCapsuleConvexAxis capsule convex normal of
+            case capsuleOverlap capsule normal (ConvexConvex.faceExtent normal group convex) of
                 Nothing ->
                     Nothing
 
@@ -526,15 +526,10 @@ the vertex-vs-cap and edge-vs-cap axes that standard convex SAT misses,
 preventing false-overlap reports near convex corners. Falls back to the
 cross product when closest points coincide.
 -}
-testUniqueEdges : Capsule -> Convex -> Vec3 -> Vec3 -> List (List Int) -> Vec3 -> Float -> Maybe Vec3
-testUniqueEdges capsule convex ep1 ep2 groups target dmin =
-    walkUniqueEdges capsule convex ep1 ep2 [] groups target dmin
-
-
-walkUniqueEdges : Capsule -> Convex -> Vec3 -> Vec3 -> List Int -> List (List Int) -> Vec3 -> Float -> Maybe Vec3
-walkUniqueEdges capsule convex ep1 ep2 edges queuedGroups target dmin =
+testUniqueEdges : Capsule -> Convex -> Vec3 -> Vec3 -> List Edge -> List Convex.EdgeGroup -> Vec3 -> Float -> Maybe Vec3
+testUniqueEdges capsule convex ep1 ep2 edges queuedGroups target dmin =
     case edges of
-        i1 :: i2 :: rest ->
+        { i1, i2 } :: rest ->
             let
                 v1 =
                     VertexBuffer.get i1 convex.vertexBuffer
@@ -544,24 +539,24 @@ walkUniqueEdges capsule convex ep1 ep2 edges queuedGroups target dmin =
             in
             case edgeAxis capsule ep1 ep2 v1 v2 of
                 Nothing ->
-                    walkUniqueEdges capsule convex ep1 ep2 rest queuedGroups target dmin
+                    testUniqueEdges capsule convex ep1 ep2 rest queuedGroups target dmin
 
                 Just axis ->
-                    case testCapsuleConvexAxis capsule convex axis of
+                    case capsuleOverlap capsule axis (ConvexConvex.projectConvex axis convex) of
                         Nothing ->
                             Nothing
 
                         Just dist ->
                             if dist - dmin < 0 then
-                                walkUniqueEdges capsule convex ep1 ep2 rest queuedGroups axis dist
+                                testUniqueEdges capsule convex ep1 ep2 rest queuedGroups axis dist
 
                             else
-                                walkUniqueEdges capsule convex ep1 ep2 rest queuedGroups target dmin
+                                testUniqueEdges capsule convex ep1 ep2 rest queuedGroups target dmin
 
         _ ->
             case queuedGroups of
                 group :: restGroups ->
-                    walkUniqueEdges capsule convex ep1 ep2 group restGroups target dmin
+                    testUniqueEdges capsule convex ep1 ep2 group.edges restGroups target dmin
 
                 [] ->
                     -- Orient the axis from convex toward capsule.
@@ -676,11 +671,11 @@ collectFirstTwoTied axis maxProj verts count v1 =
 first whose both endpoints are within tolerance of `maxProj`. Short-
 circuits on first match.
 -}
-findTiedUniqueEdge : Vec3 -> Float -> VertexBuffer -> List (List Int) -> Maybe ( Vec3, Vec3 )
+findTiedUniqueEdge : Vec3 -> Float -> VertexBuffer -> List Convex.EdgeGroup -> Maybe ( Vec3, Vec3 )
 findTiedUniqueEdge axis maxProj buffer groups =
     case groups of
         group :: restGroups ->
-            case findTiedEdgeInGroup axis maxProj buffer group of
+            case findTiedEdgeInGroup axis maxProj buffer group.edges of
                 (Just _) as found ->
                     found
 
@@ -691,10 +686,10 @@ findTiedUniqueEdge axis maxProj buffer groups =
             Nothing
 
 
-findTiedEdgeInGroup : Vec3 -> Float -> VertexBuffer -> List Int -> Maybe ( Vec3, Vec3 )
+findTiedEdgeInGroup : Vec3 -> Float -> VertexBuffer -> List Edge -> Maybe ( Vec3, Vec3 )
 findTiedEdgeInGroup axis maxProj buffer edges =
     case edges of
-        i1 :: i2 :: rest ->
+        { i1, i2 } :: rest ->
             let
                 v1 =
                     VertexBuffer.get i1 buffer
@@ -712,11 +707,11 @@ findTiedEdgeInGroup axis maxProj buffer edges =
             Nothing
 
 
-{-| Returns the overlap depth along the given axis, or Nothing if the axis
-separates the capsule from the convex.
+{-| Overlap depth of the capsule against a convex's [min,max] along `n`,
+or Nothing if they separate past the contact threshold.
 -}
-testCapsuleConvexAxis : Capsule -> Convex -> Vec3 -> Maybe Float
-testCapsuleConvexAxis { radius, halfLength, axis, position } convex n =
+capsuleOverlap : Capsule -> Vec3 -> { min : Float, max : Float } -> Maybe Float
+capsuleOverlap { radius, halfLength, axis, position } n p2 =
     let
         centerProj =
             Vec3.dot position n
@@ -729,9 +724,6 @@ testCapsuleConvexAxis { radius, halfLength, axis, position } convex n =
 
         capsuleMax =
             centerProj + axisContrib + radius
-
-        p2 =
-            ConvexConvex.projectConvex n convex
 
         d1 =
             capsuleMax - p2.min

--- a/src/Collision/ConvexConvex.elm
+++ b/src/Collision/ConvexConvex.elm
@@ -138,9 +138,10 @@ orientAxis convex1 convex2 axis =
         axis
 
 
-{-| Emit a single edge-edge contact; `axis` is already the contact normal.
-The id packs `(dir1Idx, edge1Idx, dir2Idx, edge2Idx)`, stable across
-`placeIn`, so warm-start keys survive multi-edge contacts in a body pair.
+{-| Emit a single edge-edge contact; `axis` points 2 → 1, the contact
+normal is its negation. The id packs `(dir1Idx, edge1Idx, dir2Idx, edge2Idx)`,
+stable across `placeIn`, so warm-start keys survive multi-edge contacts in a
+body pair.
 -}
 addEdgeContact : Int -> Vec3 -> Int -> Edge -> VertexBuffer -> Edge -> VertexBuffer -> List Contact -> List Contact
 addEdgeContact shapeKey axis featureKey edge1 buffer1 edge2 buffer2 contacts =
@@ -154,7 +155,7 @@ addEdgeContact shapeKey axis featureKey edge1 buffer1 edge2 buffer2 contacts =
     in
     { shapeKey = shapeKey
     , featureKey = featureKey
-    , ni = axis
+    , ni = Vec3.negate axis
     , pi = pi
     , pj = pj
     }
@@ -365,8 +366,8 @@ findSeparatingAxis convex1 convex2 =
                     Nothing
 
                 EdgeBeats _ axis _ _ _ _ _ ->
-                    -- axis points 1 → 2; match the face path's convention
-                    Just (Vec3.negate axis)
+                    -- points 2 → 1 like the face path
+                    Just axis
 
                 NoEdgeBeats _ _ _ _ _ _ _ ->
                     Just (orientAxis convex1 convex2 winner.axis)
@@ -439,7 +440,7 @@ findFaceSATHelp convex1 convex2 currentSide normals nextNormals nextGroupIdx win
 
 {-| Seven fields on every variant for one monomorphic object shape; the
 padding slots hold the running `dmin` so the loop threads no tuple.
-`EdgeBeats dist axis featureKey edge1 edge2`: convex1's outward support
+`EdgeBeats dist axis featureKey edge1 edge2`: convex2's outward support
 axis, the two support edges, and the packed warm-start contact id.
 -}
 type EdgeResult
@@ -585,12 +586,10 @@ addCandidate convex1 convex2 x2 featureKey edge1 edge2 best =
             x2.x * edge2.nB.x + x2.y * edge2.nB.y + x2.z * edge2.nB.z
 
         axisOut =
-            -- stored pointing convex1 → convex2, the face path's convention
-            Vec3.negate
-                (Vec3.normalize
-                    (Transform3d.rotate convex2.orientation
-                        (Vec3.lerp (a / (a - b)) edge2.nA edge2.nB)
-                    )
+            -- outward from convex2, pointing convex2 → convex1
+            Vec3.normalize
+                (Transform3d.rotate convex2.orientation
+                    (Vec3.lerp (a / (a - b)) edge2.nA edge2.nB)
                 )
 
         w1 =
@@ -600,7 +599,7 @@ addCandidate convex1 convex2 x2 featureKey edge1 edge2 best =
             VertexBuffer.get edge2.i1 convex2.vertexBuffer
 
         dist =
-            axisOut.x * (w1.x - w2.x) + axisOut.y * (w1.y - w2.y) + axisOut.z * (w1.z - w2.z)
+            axisOut.x * (w2.x - w1.x) + axisOut.y * (w2.y - w1.y) + axisOut.z * (w2.z - w1.z)
     in
     if dist + Const.contactBreakingThreshold < 0 then
         edgeSeparates

--- a/src/Collision/ConvexConvex.elm
+++ b/src/Collision/ConvexConvex.elm
@@ -1,19 +1,20 @@
 module Collision.ConvexConvex exposing
     ( addContacts
     , bestFace
+    , faceExtent
     , findSeparatingAxis
     , project
     , projectConvex
-    , testSeparatingAxis
     )
 
 import Internal.Const as Const
 import Internal.Contact exposing (Contact)
 import Internal.ContactId as ContactId
 import Internal.Manifold as Manifold
+import Internal.Transform3d as Transform3d exposing (Orientation3d)
 import Internal.Vector3 as Vec3 exposing (Vec3)
 import Internal.VertexBuffer as VertexBuffer exposing (VertexBuffer)
-import Shapes.Convex as Convex exposing (Convex, Face, FaceGroup(..), Obb(..))
+import Shapes.Convex as Convex exposing (Convex, Edge, EdgeGroup, Face, FaceGroup(..), Obb(..))
 
 
 {-| Which body contributed the winning face axis to SAT.
@@ -23,10 +24,9 @@ type Side
     | Convex2
 
 
-{-| Result of `findFaceSAT`. Carries the winning face's group so the
-dispatcher can skip one of the two `bestFace` walks. `groupIdx` is 1-based
-in flat traversal order, matching `bestFace` — keeps contact IDs stable
-for warm-start cache keys.
+{-| `findFaceSAT` winner. Carries the group so the dispatcher skips one
+`bestFace` walk; `groupIdx` is 1-based flat order, matching `bestFace`,
+so contact ids stay stable.
 -}
 type alias FaceWinner =
     { axis : Vec3
@@ -45,21 +45,20 @@ addContacts shapeKey convex1 convex2 contacts =
 
         Just winner ->
             case findEdgeSAT convex1 convex2 winner.dmin of
-                EdgeSeparates _ _ _ _ _ ->
+                EdgeSeparates _ _ _ _ _ _ _ ->
                     contacts
 
-                EdgeBeats edgeAxis dir1Idx edges1 dir2Idx edges2 ->
+                EdgeBeats _ axis featureKey edge1 edge2 _ _ ->
                     addEdgeContact shapeKey
-                        (orientAxis convex1 convex2 edgeAxis)
-                        dir1Idx
-                        edges1
+                        axis
+                        featureKey
+                        edge1
                         convex1.vertexBuffer
-                        dir2Idx
-                        edges2
+                        edge2
                         convex2.vertexBuffer
                         contacts
 
-                NoEdgeBeats _ _ _ _ _ ->
+                NoEdgeBeats _ _ _ _ _ _ _ ->
                     dispatchBestFaces shapeKey convex1 convex2 winner contacts
 
 
@@ -101,8 +100,7 @@ dispatchBestFaces shapeKey convex1 convex2 winner contacts =
         contacts
 
     else
-        -- face1 is always convex1's, face2 always convex2's (see the case
-        -- above), so each materialises against its own convex's buffer.
+        -- face1/face2 stay with convex1/convex2, whichever side won
         clipTwoFaces shapeKey
             picked.id1
             picked.id2
@@ -114,9 +112,8 @@ dispatchBestFaces shapeKey convex1 convex2 winner contacts =
             contacts
 
 
-{-| Pick the face in the group whose normal is most anti-aligned with
-`axisToward`. The partner's dot is the negation of the primary's, so a
-single dot product decides by sign.
+{-| The face in the group most anti-aligned with `axisToward`; one dot
+decides, the partner's is its negation.
 -}
 pickWinningFace : Int -> FaceGroup -> Vec3 -> ( Int, Face )
 pickWinningFace groupIdx group axisToward =
@@ -141,75 +138,37 @@ orientAxis convex1 convex2 axis =
         axis
 
 
-{-| Emit a single edge-edge contact. The id encodes
-`(dir1Idx, edge1Idx, dir2Idx, edge2Idx)` — stable across `placeIn`, so
-warm-start cache keys survive multi-edge contacts in the same body pair.
+{-| Emit a single edge-edge contact; `axis` is already the contact normal.
+The id packs `(dir1Idx, edge1Idx, dir2Idx, edge2Idx)`, stable across
+`placeIn`, so warm-start keys survive multi-edge contacts in a body pair.
 -}
-addEdgeContact : Int -> Vec3 -> Int -> List Int -> VertexBuffer -> Int -> List Int -> VertexBuffer -> List Contact -> List Contact
-addEdgeContact shapeKey separatingAxis dir1Idx edges1 buffer1 dir2Idx edges2 buffer2 contacts =
+addEdgeContact : Int -> Vec3 -> Int -> Edge -> VertexBuffer -> Edge -> VertexBuffer -> List Contact -> List Contact
+addEdgeContact shapeKey axis featureKey edge1 buffer1 edge2 buffer2 contacts =
     let
-        reversedSeparatingAxis =
-            Vec3.negate separatingAxis
-
-        ( edge1Idx, ( e1p, e1q ) ) =
-            pickSupportEdge reversedSeparatingAxis edges1 buffer1
-
-        ( edge2Idx, ( e2p, e2q ) ) =
-            pickSupportEdge separatingAxis edges2 buffer2
-
         ( pi, pj ) =
-            Vec3.closestPointsBetweenSegments e1p e1q e2p e2q
+            Vec3.closestPointsBetweenSegments
+                (VertexBuffer.get edge1.i1 buffer1)
+                (VertexBuffer.get edge1.i2 buffer1)
+                (VertexBuffer.get edge2.i1 buffer2)
+                (VertexBuffer.get edge2.i2 buffer2)
     in
     { shapeKey = shapeKey
-    , featureKey = ContactId.convexConvexEdge dir1Idx edge1Idx dir2Idx edge2Idx
-    , ni = reversedSeparatingAxis
+    , featureKey = featureKey
+    , ni = axis
     , pi = pi
     , pj = pj
     }
         :: contacts
 
 
-{-| Pick the edge in a direction group whose midpoint is furthest along
-`supportDir`. The 1-based index is part of the warm-start cache key.
--}
-pickSupportEdge : Vec3 -> List Int -> VertexBuffer -> ( Int, ( Vec3, Vec3 ) )
-pickSupportEdge supportDir edges buffer =
-    pickSupportEdgeHelp supportDir edges buffer 1 0 ( Vec3.zero, Vec3.zero ) -Const.maxNumber
-
-
-pickSupportEdgeHelp : Vec3 -> List Int -> VertexBuffer -> Int -> Int -> ( Vec3, Vec3 ) -> Float -> ( Int, ( Vec3, Vec3 ) )
-pickSupportEdgeHelp supportDir edges buffer idx bestIdx bestEdge bestDot =
-    case edges of
-        i1 :: i2 :: rest ->
-            let
-                v1 =
-                    VertexBuffer.get i1 buffer
-
-                v2 =
-                    VertexBuffer.get i2 buffer
-
-                midDot =
-                    supportDir.x * (v1.x + v2.x) + supportDir.y * (v1.y + v2.y) + supportDir.z * (v1.z + v2.z)
-            in
-            if midDot - bestDot > 0 then
-                pickSupportEdgeHelp supportDir rest buffer (idx + 1) idx ( v1, v2 ) midDot
-
-            else
-                pickSupportEdgeHelp supportDir rest buffer (idx + 1) bestIdx bestEdge bestDot
-
-        _ ->
-            ( bestIdx, bestEdge )
-
-
 clipTwoFaces : Int -> Int -> Int -> Face -> VertexBuffer -> Face -> VertexBuffer -> Vec3 -> List Contact -> List Contact
 clipTwoFaces shapeKey faceId1 faceId2 face faceBuffer incidentFace incidentBuffer separatingAxis contacts =
     let
-        -- Only the two contacting faces are materialised, on demand.
+        -- only the two contacting faces are materialised
         referenceVertices =
             Convex.faceVertices faceBuffer face
 
-        -- Each vertex carries its buffer index as the warm-start key, threaded
-        -- through the clip so it survives the cull.
+        -- vertices carry buffer indices as warm-start keys through the clip
         incidentPolygon =
             Convex.indexedFaceVertices incidentBuffer incidentFace
 
@@ -269,9 +228,8 @@ emitManifold shapeKey faceId1 faceId2 separatingAxis normal planeConstant points
             result
 
 
-{-| Finds the face whose normal is most aligned with `-separatingAxis`.
-The partner is the antiparallel of the primary, so one dot per group
-covers both. Returns `( -1, emptyFace )` for empty groups.
+{-| The face most aligned with `-separatingAxis`; one dot per group covers
+the antiparallel partner. `( -1, emptyFace )` when there are no groups.
 -}
 bestFace : List FaceGroup -> Vec3 -> ( Int, Face )
 bestFace groups separatingAxis =
@@ -403,19 +361,19 @@ findSeparatingAxis convex1 convex2 =
 
         Just winner ->
             case findEdgeSAT convex1 convex2 winner.dmin of
-                EdgeSeparates _ _ _ _ _ ->
+                EdgeSeparates _ _ _ _ _ _ _ ->
                     Nothing
 
-                EdgeBeats edgeAxis _ _ _ _ ->
-                    Just (orientAxis convex1 convex2 edgeAxis)
+                EdgeBeats _ axis _ _ _ _ _ ->
+                    -- axis points 1 → 2; match the face path's convention
+                    Just (Vec3.negate axis)
 
-                NoEdgeBeats _ _ _ _ _ ->
+                NoEdgeBeats _ _ _ _ _ _ _ ->
                     Just (orientAxis convex1 convex2 winner.axis)
 
 
-{-| Test every face group's direction as a SAT axis. Returns the winning
-body + group so `dispatchBestFaces` can skip one of the two `bestFace`
-walks while keeping contact IDs stable.
+{-| Test every face group's direction as a SAT axis; return the winning
+side + group so the dispatcher skips one `bestFace` walk.
 -}
 findFaceSAT : Convex -> Convex -> Maybe FaceWinner
 findFaceSAT convex1 convex2 =
@@ -479,26 +437,33 @@ findFaceSATHelp convex1 convex2 currentSide normals nextNormals nextGroupIdx win
                         findFaceSATHelp convex1 convex2 currentSide restNormals nextNormals (nextGroupIdx + groupSize) winnerIdx winnerSide winnerGroup dmin
 
 
-{-| The two nullary cases carry five `()` fields so all three variants share
-`EdgeBeats`'s object shape — a monomorphic `.$` for the consuming `case` and for
-the `best` accumulator threaded through `findEdgeSATHelp`. They're built once as
-`edgeSeparates`/`noEdgeBeats` constants and reused, so the padding costs no
-per-call allocation (unlike re-applying the constructor each time).
+{-| Seven fields on every variant for one monomorphic object shape; the
+padding slots hold the running `dmin` so the loop threads no tuple.
+`EdgeBeats dist axis featureKey edge1 edge2`: convex1's outward support
+axis, the two support edges, and the packed warm-start contact id.
 -}
 type EdgeResult
-    = EdgeSeparates () () () () ()
-    | EdgeBeats Vec3 Int (List Int) Int (List Int)
-    | NoEdgeBeats () () () () ()
+    = EdgeSeparates Float () () () () () ()
+    | EdgeBeats Float Vec3 Int Edge Edge () ()
+    | NoEdgeBeats Float () () () () () ()
 
 
 edgeSeparates : EdgeResult
 edgeSeparates =
-    EdgeSeparates () () () () ()
+    EdgeSeparates 0 () () () () () ()
 
 
-noEdgeBeats : EdgeResult
-noEdgeBeats =
-    NoEdgeBeats () () () () ()
+edgeDmin : EdgeResult -> Float
+edgeDmin best =
+    case best of
+        EdgeBeats d _ _ _ _ _ _ ->
+            d
+
+        NoEdgeBeats d _ _ _ _ _ _ ->
+            d
+
+        EdgeSeparates d _ _ _ _ _ _ ->
+            d
 
 
 {-| Edge SAT must beat face SAT by 5% to take the edge-edge path; relative so it
@@ -509,84 +474,193 @@ edgeBiasFactor =
     1.05
 
 
-{-| Iterate `(dir1, dir2)` pairs of unique edge directions. The winner
-stores its full edge list so the support-edge picker walks only parallel
-edges (4 for a cube) instead of all face-edges. Direction indices are
-1-based, stable under `placeIn` — safe to encode in contact ids.
+{-| Iterate `(dir1, dir2)` pairs of unique edge directions. A pair matters
+only when arcs of each group cross the other's great circle in consistent
+hemispheres — the crossing point is the axis. A miss (incl. parallel
+directions: coincident circles) prunes with no cross product, normalize or
+projection. Direction indices are 1-based, stable under `placeIn`.
 -}
 findEdgeSAT : Convex -> Convex -> Float -> EdgeResult
 findEdgeSAT convex1 convex2 faceDmin =
-    -- Pre-bias the threshold so the loop runs plain `dist < dmin`.
-    findEdgeSATHelp convex1
+    -- threshold pre-biased so the loop compares plain `dist < dmin`
+    findEdgeSATOuter convex1
         convex2
-        convex2.uniqueEdges
+        (Transform3d.relativeOrientation convex1.orientation convex2.orientation)
         convex1.uniqueEdges
-        convex2.uniqueEdges
         1
-        1
-        noEdgeBeats
-        (faceDmin / edgeBiasFactor)
+        (NoEdgeBeats (faceDmin / edgeBiasFactor) () () () () () ())
 
 
-findEdgeSATHelp : Convex -> Convex -> List (List Int) -> List (List Int) -> List (List Int) -> Int -> Int -> EdgeResult -> Float -> EdgeResult
-findEdgeSATHelp convex1 convex2 initGroups2 groups1 groups2 dir1Idx dir2Idx best dmin =
+findEdgeSATOuter : Convex -> Convex -> Orientation3d -> List EdgeGroup -> Int -> EdgeResult -> EdgeResult
+findEdgeSATOuter convex1 convex2 relative groups1 dir1Idx best =
     case groups1 of
+        group1 :: rest1 ->
+            -- group1's direction in convex2's frame, fixed across the inner loop
+            case findEdgeSATInner convex1 convex2 relative group1 (Transform3d.derotate relative group1.dir) dir1Idx convex2.uniqueEdges 1 best of
+                (EdgeSeparates _ _ _ _ _ _ _) as separated ->
+                    separated
+
+                newBest ->
+                    findEdgeSATOuter convex1 convex2 relative rest1 (dir1Idx + 1) newBest
+
         [] ->
             best
 
-        ((v1a :: v1b :: _) as group1) :: remainingGroups1 ->
-            case groups2 of
-                [] ->
-                    -- requeue groups2 and advance outer
-                    findEdgeSATHelp convex1 convex2 initGroups2 remainingGroups1 initGroups2 (dir1Idx + 1) 1 best dmin
 
-                ((v2a :: v2b :: _) as group2) :: remainingGroups2 ->
+findEdgeSATInner : Convex -> Convex -> Orientation3d -> EdgeGroup -> Vec3 -> Int -> List EdgeGroup -> Int -> EdgeResult -> EdgeResult
+findEdgeSATInner convex1 convex2 relative group1 x2 dir1Idx groups2 dir2Idx best =
+    case groups2 of
+        group2 :: rest2 ->
+            let
+                -- group2's direction in convex1's frame
+                x1 =
+                    Transform3d.rotate relative group2.dir
+
+                cosd =
+                    Vec3.dot x1 group1.dir
+            in
+            -- near-parallel: the crossing is ill-conditioned and the face
+            -- phase covers these
+            if 1 - cosd * cosd - Const.parallelTolerance < 0 then
+                findEdgeSATInner convex1 convex2 relative group1 x2 dir1Idx rest2 (dir2Idx + 1) best
+
+            else
+                let
+                    hits1 =
+                        scanCrossings x1 group1.edges
+                in
+                if hits1.posIdx == 0 && hits1.negIdx == 0 then
+                    findEdgeSATInner convex1 convex2 relative group1 x2 dir1Idx rest2 (dir2Idx + 1) best
+
+                else
                     let
-                        dir1 =
-                            Vec3.direction (VertexBuffer.get v1a convex1.vertexBuffer) (VertexBuffer.get v1b convex1.vertexBuffer)
-
-                        dir2 =
-                            Vec3.direction (VertexBuffer.get v2a convex2.vertexBuffer) (VertexBuffer.get v2b convex2.vertexBuffer)
-
-                        cross =
-                            Vec3.cross dir1 dir2
+                        hits2 =
+                            scanCrossings x2 group2.edges
                     in
-                    if Vec3.almostZero cross then
-                        -- skip parallel directions
-                        findEdgeSATHelp convex1 convex2 initGroups2 groups1 remainingGroups2 dir1Idx (dir2Idx + 1) best dmin
+                    -- candidates pair by hemisphere class (sign of the nA dot)
+                    if (hits1.posIdx == 0 || hits2.posIdx == 0) && (hits1.negIdx == 0 || hits2.negIdx == 0) then
+                        findEdgeSATInner convex1 convex2 relative group1 x2 dir1Idx rest2 (dir2Idx + 1) best
 
                     else
                         let
-                            normalizedCross =
-                                Vec3.normalize cross
-                        in
-                        case testSeparatingAxis convex1 convex2 normalizedCross of
-                            Nothing ->
-                                edgeSeparates
-
-                            Just dist ->
-                                if dist - dmin < 0 then
-                                    findEdgeSATHelp convex1 convex2 initGroups2 groups1 remainingGroups2 dir1Idx (dir2Idx + 1) (EdgeBeats normalizedCross dir1Idx group1 dir2Idx group2) dist
+                            afterPos =
+                                if hits1.posIdx > 0 && hits2.posIdx > 0 then
+                                    addCandidate convex1 convex2 x2 (ContactId.convexConvexEdge dir1Idx hits1.posIdx dir2Idx hits2.posIdx) hits1.pos hits2.pos best
 
                                 else
-                                    findEdgeSATHelp convex1 convex2 initGroups2 groups1 remainingGroups2 dir1Idx (dir2Idx + 1) best dmin
+                                    best
+                        in
+                        case afterPos of
+                            (EdgeSeparates _ _ _ _ _ _ _) as separated ->
+                                separated
 
-                _ :: remainingGroups2 ->
-                    -- malformed group2 (< 2 points): skip
-                    findEdgeSATHelp convex1 convex2 initGroups2 groups1 remainingGroups2 dir1Idx (dir2Idx + 1) best dmin
+                            best1 ->
+                                if hits1.negIdx > 0 && hits2.negIdx > 0 then
+                                    case addCandidate convex1 convex2 x2 (ContactId.convexConvexEdge dir1Idx hits1.negIdx dir2Idx hits2.negIdx) hits1.neg hits2.neg best1 of
+                                        (EdgeSeparates _ _ _ _ _ _ _) as separated ->
+                                            separated
 
-        _ :: remainingGroups1 ->
-            -- malformed group (< 2 points): skip
-            findEdgeSATHelp convex1 convex2 initGroups2 remainingGroups1 groups2 (dir1Idx + 1) dir2Idx best dmin
+                                        best2 ->
+                                            findEdgeSATInner convex1 convex2 relative group1 x2 dir1Idx rest2 (dir2Idx + 1) best2
+
+                                else
+                                    findEdgeSATInner convex1 convex2 relative group1 x2 dir1Idx rest2 (dir2Idx + 1) best1
+
+        [] ->
+            best
 
 
-{-| If projections of two convexes don’t overlap, then they don’t collide.
+{-| Fold one edge-pair candidate into the running best. The axis is the arc
+crossing point — a blend of convex2's outward normals, so no centre check;
+a support edge's endpoints project equally, so one endpoint each gives the
+exact depth. `EdgeSeparates` is a separating-axis certificate.
 -}
-testSeparatingAxis : Convex -> Convex -> Vec3 -> Maybe Float
-testSeparatingAxis convex1 convex2 separatingAxis =
-    overlap
-        (projectConvex separatingAxis convex1)
-        (projectConvex separatingAxis convex2)
+addCandidate : Convex -> Convex -> Vec3 -> Int -> Edge -> Edge -> EdgeResult -> EdgeResult
+addCandidate convex1 convex2 x2 featureKey edge1 edge2 best =
+    let
+        a =
+            x2.x * edge2.nA.x + x2.y * edge2.nA.y + x2.z * edge2.nA.z
+
+        b =
+            x2.x * edge2.nB.x + x2.y * edge2.nB.y + x2.z * edge2.nB.z
+
+        axisOut =
+            -- stored pointing convex1 → convex2, the face path's convention
+            Vec3.negate
+                (Vec3.normalize
+                    (Transform3d.rotate convex2.orientation
+                        (Vec3.lerp (a / (a - b)) edge2.nA edge2.nB)
+                    )
+                )
+
+        w1 =
+            VertexBuffer.get edge1.i1 convex1.vertexBuffer
+
+        w2 =
+            VertexBuffer.get edge2.i1 convex2.vertexBuffer
+
+        dist =
+            axisOut.x * (w1.x - w2.x) + axisOut.y * (w1.y - w2.y) + axisOut.z * (w1.z - w2.z)
+    in
+    if dist + Const.contactBreakingThreshold < 0 then
+        edgeSeparates
+
+    else if dist - edgeDmin best < 0 then
+        EdgeBeats dist axisOut featureKey edge1 edge2 () ()
+
+    else
+        best
+
+
+{-| Which edges of the group have arcs straddling the great circle ⊥ `x`
+(the other group's direction in this body's frame). At most one hit per
+hemisphere class (sign of the `nA` dot); the dots ride along for the axis
+lerp. Indices are 1-based; 0 means no hit.
+-}
+scanCrossings : Vec3 -> List Edge -> Crossings
+scanCrossings x edges =
+    scanCrossingsHelp x edges 1 0 emptyEdge 0 emptyEdge
+
+
+type alias Crossings =
+    { posIdx : Int, pos : Edge, negIdx : Int, neg : Edge }
+
+
+emptyEdge : Edge
+emptyEdge =
+    { i1 = -1, i2 = -1, nA = Vec3.zero, nB = Vec3.zero }
+
+
+scanCrossingsHelp : Vec3 -> List Edge -> Int -> Int -> Edge -> Int -> Edge -> Crossings
+scanCrossingsHelp x edges idx posIdx pos negIdx neg =
+    case edges of
+        edge :: rest ->
+            let
+                a =
+                    x.x * edge.nA.x + x.y * edge.nA.y + x.z * edge.nA.z
+
+                b =
+                    x.x * edge.nB.x + x.y * edge.nB.y + x.z * edge.nB.z
+            in
+            -- straddle, with a noise floor: both dots ≈ 0 makes the sign
+            -- test garbage — treat as no crossing
+            if a * b < 0 && (a * a - parallelSquaredTolerance > 0 || b * b - parallelSquaredTolerance > 0) then
+                if a > 0 then
+                    scanCrossingsHelp x rest (idx + 1) idx edge negIdx neg
+
+                else
+                    scanCrossingsHelp x rest (idx + 1) posIdx pos idx edge
+
+            else
+                scanCrossingsHelp x rest (idx + 1) posIdx pos negIdx neg
+
+        [] ->
+            { posIdx = posIdx, pos = pos, negIdx = negIdx, neg = neg }
+
+
+parallelSquaredTolerance : Float
+parallelSquaredTolerance =
+    Const.precision * Const.precision
 
 
 {-| A convex's [min,max] projection onto `axis`. A box projects in O(1) from its
@@ -610,17 +684,10 @@ projectConvex axis convex =
             project axis Const.maxNumber -Const.maxNumber vs
 
 
-{-| SAT for a face-normal axis. The axis is `owningSide`'s face normal, so that
-convex's extent along it is the constant body-space `faceDist`/`partnerDist`
-(face / antipodal partner distance from the centroid) plus one shared
-`dot(axis, position)`. The other convex projects via `projectConvex` — also O(1)
-when it's a box.
-
-Not byte-identical: `faceDist + dot(n, pos)` (and the box extent) ≠ `max` over
-the vertices in the last bit (FP), enough to flip a borderline face/edge tie.
-Behaviour stays valid (tests pass); the chaotic drop checksum shifts, a resting
-scene barely.
-
+{-| SAT for a face-normal axis: the owning convex's extent is the cached
+`faceDist`/`partnerDist` plus one `dot(axis, position)`; the other side
+projects via `projectConvex`. Differs from a vertex scan in the last FP
+bit — enough to flip a borderline face/edge tie.
 -}
 testFaceSeparatingAxis : Convex -> Convex -> Side -> FaceGroup -> Maybe Float
 testFaceSeparatingAxis convex1 convex2 owningSide group =

--- a/src/Internal/Transform3d.elm
+++ b/src/Internal/Transform3d.elm
@@ -1,10 +1,13 @@
 module Internal.Transform3d exposing
-    ( Transform3d
+    ( Orientation3d
+    , Transform3d
     , atOrigin
     , atPoint
+    , derotate
     , directionPlaceIn
     , directionRelativeTo
     , fromOriginAndBasis
+    , identity
     , inertiaPlaceIn
     , inertiaRotateIn
     , inverse
@@ -13,11 +16,14 @@ module Internal.Transform3d exposing
     , moveTo
     , normalize
     , orientation
+    , orientationPlaceIn
     , originPoint
     , placeIn
     , pointPlaceIn
     , pointRelativeTo
+    , relativeOrientation
     , relativeTo
+    , rotate
     , rotateAroundOwn
     , rotateBy
     , translateBy
@@ -329,6 +335,41 @@ lerp t (Transform3d o1 (Orientation3d x1 y1 z1 w1)) (Transform3d o2 (Orientation
 originPoint : Transform3d coordinates defines -> Vec3
 originPoint (Transform3d localOrigin _) =
     localOrigin
+
+
+{-| Accumulate a placement onto a stored orientation; shares the transform's
+quaternion by reference when the stored one is identity.
+-}
+orientationPlaceIn : Transform3d coordinates defines -> Orientation3d -> Orientation3d
+orientationPlaceIn (Transform3d _ globalOrientation) localOrientation =
+    if localOrientation == identity then
+        globalOrientation
+
+    else
+        mul globalOrientation localOrientation
+
+
+{-| The rotation taking a direction from `b`'s frame to `a`'s: `a* ⊗ b`.
+`rotate` crosses `b`-body → `a`-body; `derotate` reverses.
+-}
+relativeOrientation : Orientation3d -> Orientation3d -> Orientation3d
+relativeOrientation (Orientation3d ax ay az aw) (Orientation3d bx by bz bw) =
+    -- `mul` with the first quaternion conjugated inline (`q1x/y/z`)
+    let
+        q1x =
+            -ax
+
+        q1y =
+            -ay
+
+        q1z =
+            -az
+    in
+    Orientation3d
+        (q1x * bw + q1y * bz - q1z * by + aw * bx)
+        (-q1x * bz + q1y * bw + q1z * bx + aw * by)
+        (q1x * by - q1y * bx + q1z * bw + aw * bz)
+        (-q1x * bx - q1y * by - q1z * bz + aw * bw)
 
 
 orientation : Transform3d coordinates defines -> Mat3

--- a/src/Shapes/Convex.elm
+++ b/src/Shapes/Convex.elm
@@ -1,5 +1,7 @@
 module Shapes.Convex exposing
     ( Convex
+    , Edge
+    , EdgeGroup
     , Face
     , FaceGroup(..)
     , FaceVertices
@@ -73,26 +75,44 @@ type alias FaceVertices =
     }
 
 
+{-| An edge (`i1`/`i2` index the `vertexBuffer`) with its Gauss arc: the
+body-frame outward normals of the two adjacent faces, `nA` left / `nB`
+right along the group direction (every edge is canonicalized to it). The
+arc crosses the great circle ⊥ `x` iff `(nA·x)(nB·x) < 0`; degenerate arcs
+get `nB ≈ nA` or zeros, so the straddle never fires.
+-}
+type alias Edge =
+    { i1 : Int
+    , i2 : Int
+    , nA : Vec3
+    , nB : Vec3
+    }
+
+
+{-| A parallel-edge direction group: the shared body-frame unit direction
+(fixed at `init`) and the edges canonicalized to it.
+-}
+type alias EdgeGroup =
+    { dir : Vec3
+    , edges : List Edge
+    }
+
+
 type alias Convex =
-    -- Faces grouped by parallel/antiparallel normal direction: each group is a
-    -- primary face and `Just` its antipodal partner, or `Nothing` for a 1-face
-    -- group. uniqueEdges groups edges similarly; each physical edge appears
-    -- exactly once. Each group is a flat list of endpoint indices read
-    -- two-at-a-time (the first pair is the direction representative). (dirIdx,
-    -- edgeIdx) is stable under `placeIn` so collision code can encode indices
-    -- into contact ids for warm-start cache stability.
+    -- Faces and edges grouped by direction; each physical edge appears once.
+    -- Group/edge indices are stable under `placeIn`, so collision code packs
+    -- them into contact ids for warm-start keys.
     --
-    -- `faces` and `uniqueEdges` hold `Int` indices into `vertexBuffer`, fixed at
-    -- `init`. `placeIn` places the buffer once and rebuilds only `faces` (to
-    -- place the normals); each face's vertex-index list is shared unchanged and
-    -- `uniqueEdges` is shared whole, so no per-vertex `Vec3` list is rebuilt —
-    -- collision dereferences indices via `VertexBuffer.get`. `obb` carries the
-    -- placed `List Vec3` for a general hull (`NotBox`), or the box's axes +
-    -- half-extents for a box (`Box`); see `Obb` and `convexVertices`.
+    -- `faces`/`uniqueEdges` hold indices into `vertexBuffer`, fixed at `init`.
+    -- `placeIn` places the buffer and face normals; `uniqueEdges` is shared
+    -- whole — arcs stay in the construction frame and cross frames via the
+    -- accumulated `orientation`. `obb` is the box fast path or the placed
+    -- vertex list (see `Obb`).
     { faces : List FaceGroup
-    , uniqueEdges : List (List Int)
+    , uniqueEdges : List EdgeGroup
     , vertexBuffer : VertexBuffer
     , obb : Obb
+    , orientation : Transform3d.Orientation3d
     , position : Vec3
     , inertia : Mat3
     , volume : Float
@@ -173,6 +193,7 @@ placeIn transform3d convex =
     , uniqueEdges = convex.uniqueEdges
     , vertexBuffer = placedBuffer
     , obb = placeObb transform3d placedBuffer convex.obb
+    , orientation = Transform3d.orientationPlaceIn transform3d convex.orientation
     , position = Transform3d.pointPlaceIn transform3d convex.position
     , inertia = Transform3d.inertiaRotateIn transform3d convex.inertia
     , volume = convex.volume
@@ -310,11 +331,24 @@ init geometry =
 
         faces =
             indexFaces geometry.position geometry.vertices geometry.faces
+
+        allFaces =
+            List.concatMap
+                (\( primary, partner ) ->
+                    case partner of
+                        Just p ->
+                            [ primary, p ]
+
+                        Nothing ->
+                            [ primary ]
+                )
+                geometry.faces
     in
     { faces = faces
-    , uniqueEdges = indexEdges geometry.vertices (List.reverse geometry.uniqueEdges)
+    , uniqueEdges = indexEdges allFaces geometry.vertices (List.reverse geometry.uniqueEdges)
     , vertexBuffer = buffer
     , obb = detectObb faces geometry.vertices
+    , orientation = Transform3d.identity
     , position = geometry.position
     , inertia = geometry.inertia
     , volume = geometry.volume
@@ -365,12 +399,101 @@ faceDistance normal centroid vertices =
             0
 
 
-{-| Each group's endpoints, reversed so collision walks them in the order the
-old per-frame `pointsPlaceIn` produced.
+{-| Each group's endpoint pairs become `Edge`s with arcs. Prepend + endpoint
+swap keep the historical edge order, so (dirIdx, edgeIdx) contact ids are
+unchanged; a second pass canonicalizes normals to the representative.
 -}
-indexEdges : List Vec3 -> List (List Vec3) -> List (List Int)
-indexEdges vertices groups =
-    List.map (\group -> List.reverse (List.map (\v -> indexOf v vertices) group)) groups
+indexEdges : List FaceVertices -> List Vec3 -> List (List Vec3) -> List EdgeGroup
+indexEdges faces vertices groups =
+    List.map (canonicalizeGroup << indexEdgeGroup faces vertices []) groups
+
+
+indexEdgeGroup : List FaceVertices -> List Vec3 -> List ( Vec3, Edge ) -> List Vec3 -> List ( Vec3, Edge )
+indexEdgeGroup faces vertices acc endpoints =
+    case endpoints of
+        v1 :: v2 :: rest ->
+            indexEdgeGroup faces vertices (( Vec3.sub v1 v2, makeEdge faces vertices v2 v1 ) :: acc) rest
+
+        _ ->
+            acc
+
+
+{-| Antiparallel edges swap `nA`/`nB`, so the pair reads consistently along
+the group direction.
+-}
+canonicalizeGroup : List ( Vec3, Edge ) -> EdgeGroup
+canonicalizeGroup entries =
+    case entries of
+        ( dRep, _ ) :: _ ->
+            { dir = Vec3.normalize dRep
+            , edges =
+                List.map
+                    (\( d, edge ) ->
+                        if Vec3.dot d dRep < 0 then
+                            { i1 = edge.i1, i2 = edge.i2, nA = edge.nB, nB = edge.nA }
+
+                        else
+                            edge
+                    )
+                    entries
+            }
+
+        [] ->
+            { dir = Vec3.zero, edges = [] }
+
+
+makeEdge : List FaceVertices -> List Vec3 -> Vec3 -> Vec3 -> Edge
+makeEdge faces vertices v1 v2 =
+    { i1 = indexOf v1 vertices
+    , i2 = indexOf v2 vertices
+    , nA = adjacentNormal v1 v2 faces
+    , nB = adjacentNormal v2 v1 faces
+    }
+
+
+{-| Normal of the face whose boundary walks `v1 → v2`, matched within
+`precision` (construction can duplicate vertices bitwise-off). Zero when
+unmatched — a dead arc that never straddles.
+-}
+adjacentNormal : Vec3 -> Vec3 -> List FaceVertices -> Vec3
+adjacentNormal v1 v2 faces =
+    case faces of
+        face :: rest ->
+            case face.vertices of
+                first :: _ ->
+                    if hasDirectedEdge v1 v2 first face.vertices then
+                        face.normal
+
+                    else
+                        adjacentNormal v1 v2 rest
+
+                [] ->
+                    adjacentNormal v1 v2 rest
+
+        [] ->
+            Vec3.zero
+
+
+hasDirectedEdge : Vec3 -> Vec3 -> Vec3 -> List Vec3 -> Bool
+hasDirectedEdge v1 v2 first vertices =
+    case vertices of
+        a :: ((b :: _) as rest) ->
+            if nearVertex a v1 && nearVertex b v2 then
+                True
+
+            else
+                hasDirectedEdge v1 v2 first rest
+
+        [ last ] ->
+            nearVertex last v1 && nearVertex first v2
+
+        [] ->
+            False
+
+
+nearVertex : Vec3 -> Vec3 -> Bool
+nearVertex a b =
+    Vec3.lengthSquared (Vec3.sub a b) - Const.precision * Const.precision < 0
 
 
 {-| Distinct vertices by structural equality, preserving none-in-particular

--- a/tests/Collision/ConvexConvexTest.elm
+++ b/tests/Collision/ConvexConvexTest.elm
@@ -1,5 +1,6 @@
 module Collision.ConvexConvexTest exposing
     ( addContacts
+    , edgeOracle
     , findSeparatingAxis
     , project
     , testSeparatingAxis
@@ -7,12 +8,14 @@ module Collision.ConvexConvexTest exposing
 
 import Collision.ConvexConvex
 import Expect
+import Fuzz exposing (Fuzzer)
 import Internal.Const as Const
 import Internal.ContactId as ContactId
 import Internal.Transform3d as Transform3d
 import Internal.Vector3 as Vec3
+import Internal.VertexBuffer as VertexBuffer
 import Shapes.Convex as Convex
-import Test exposing (Test, describe, test)
+import Test exposing (Test, describe, fuzz, test)
 
 
 addContacts : Test
@@ -162,7 +165,7 @@ addContacts =
 
 testSeparatingAxis : Test
 testSeparatingAxis =
-    describe "Collision.ConvexConvex.testSeparatingAxis"
+    describe "separationAlong"
         [ test "returns Just depth" <|
             \_ ->
                 let
@@ -175,7 +178,7 @@ testSeparatingAxis =
                             |> Convex.placeIn (Transform3d.atPoint { x = 0.2, y = 0, z = 0 })
                 in
                 Expect.equal
-                    (Collision.ConvexConvex.testSeparatingAxis convex1 convex2 Vec3.xAxis)
+                    (separationAlong convex1 convex2 Vec3.xAxis)
                     (Just 0.6)
         , test "returns Nothing" <|
             \_ ->
@@ -189,7 +192,7 @@ testSeparatingAxis =
                             |> Convex.placeIn (Transform3d.atPoint { x = 0.2, y = 0, z = 0 })
                 in
                 Expect.equal
-                    (Collision.ConvexConvex.testSeparatingAxis convex1 convex2 Vec3.xAxis)
+                    (separationAlong convex1 convex2 Vec3.xAxis)
                     Nothing
         , test "works with rotation" <|
             \_ ->
@@ -206,7 +209,7 @@ testSeparatingAxis =
                                         |> Transform3d.rotateAroundOwn Vec3.zAxis (pi / 4)
                                     )
                     in
-                    Collision.ConvexConvex.testSeparatingAxis convex1 convex2 Vec3.xAxis
+                    separationAlong convex1 convex2 Vec3.xAxis
                 of
                     Nothing ->
                         Expect.fail "expected depth"
@@ -317,3 +320,256 @@ project =
                         , .max >> Expect.within (Expect.Absolute 0.00001) 1.5
                         ]
         ]
+
+
+{-| Projection-based separation depth along `axis`: `Just depth` when the two
+hulls' [min,max] intervals overlap, `Nothing` when they clear the contact
+margin. An independent reference for the arc SAT — projects both hulls (via the
+production `projectConvex`) and checks interval overlap, sharing no logic with
+the Gauss-arc path it is used to cross-check.
+-}
+separationAlong : Convex.Convex -> Convex.Convex -> Vec3.Vec3 -> Maybe Float
+separationAlong convex1 convex2 axis =
+    let
+        o =
+            overlapAlong convex1 convex2 axis
+    in
+    if o + Const.contactBreakingThreshold < 0 then
+        Nothing
+
+    else
+        Just o
+
+
+{-| Interval overlap of the two hulls' projections along `axis` (negative =
+gap), via the production `projectConvex` — no logic shared with the arc path.
+-}
+overlapAlong : Convex.Convex -> Convex.Convex -> Vec3.Vec3 -> Float
+overlapAlong convex1 convex2 axis =
+    let
+        p1 =
+            Collision.ConvexConvex.projectConvex axis convex1
+
+        p2 =
+            Collision.ConvexConvex.projectConvex axis convex2
+    in
+    min (p1.max - p2.min) (p2.max - p1.min)
+
+
+{-| Independent reimplementation of the certified axis set: face normals
+plus old-style fan containment on the normalized cross, in world frame.
+`strictMin` covers the axes the arc SAT tests, `looseMin` also the
+near-parallel pairs it prunes; a pose whose verdict hangs on a pruned pair
+or sits within `oracleBand` of the contact threshold is legitimately
+either way — skipped.
+-}
+edgeOracle : Test
+edgeOracle =
+    describe "Collision.ConvexConvex.findSeparatingAxis oracle"
+        [ fuzz poseFuzzer "agrees with the containment oracle" <|
+            \pose ->
+                let
+                    convex1 =
+                        Convex.placeIn
+                            (Transform3d.atOrigin
+                                |> Transform3d.rotateAroundOwn pose.axis1 pose.angle1
+                            )
+                            pose.shape1
+
+                    convex2 =
+                        Convex.placeIn
+                            (Transform3d.atPoint (Vec3.scale pose.offset pose.offsetDir)
+                                |> Transform3d.rotateAroundOwn pose.axis2 pose.angle2
+                            )
+                            pose.shape2
+
+                    satSeparated =
+                        Collision.ConvexConvex.findSeparatingAxis convex1 convex2 == Nothing
+
+                    faceMin =
+                        List.foldl (\n o -> min o (overlapAlong convex1 convex2 n))
+                            Const.maxNumber
+                            (List.map Convex.faceGroupNormal convex1.faces
+                                ++ List.map Convex.faceGroupNormal convex2.faces
+                            )
+
+                    ( strictMin, looseMin ) =
+                        edgeMinOverlaps convex1 convex2 faceMin
+                in
+                if strictMin + Const.contactBreakingThreshold + oracleBand < 0 then
+                    satSeparated
+                        |> Expect.equal True
+                        |> Expect.onFail "oracle separated, arc SAT colliding"
+
+                else if looseMin + Const.contactBreakingThreshold - oracleBand > 0 then
+                    satSeparated
+                        |> Expect.equal False
+                        |> Expect.onFail "oracle colliding, arc SAT separated"
+
+                else
+                    Expect.pass
+        ]
+
+
+{-| FP slack between the oracle's arithmetic and the arc SAT's, including
+its scan noise floors.
+-}
+oracleBand : Float
+oracleBand =
+    1.0e-5
+
+
+type alias Pose =
+    { shape1 : Convex.Convex
+    , shape2 : Convex.Convex
+    , axis1 : Vec3.Vec3
+    , angle1 : Float
+    , axis2 : Vec3.Vec3
+    , angle2 : Float
+    , offsetDir : Vec3.Vec3
+    , offset : Float
+    }
+
+
+poseFuzzer : Fuzzer Pose
+poseFuzzer =
+    Fuzz.constant Pose
+        |> Fuzz.andMap shapeFuzzer
+        |> Fuzz.andMap shapeFuzzer
+        |> Fuzz.andMap directionFuzzer
+        |> Fuzz.andMap (Fuzz.floatRange 0 (2 * pi))
+        |> Fuzz.andMap directionFuzzer
+        |> Fuzz.andMap (Fuzz.floatRange 0 (2 * pi))
+        |> Fuzz.andMap directionFuzzer
+        |> Fuzz.andMap (Fuzz.floatRange 0.8 3)
+
+
+shapeFuzzer : Fuzzer Convex.Convex
+shapeFuzzer =
+    Fuzz.oneOfValues
+        [ Convex.fromBlock 1.5 1 2
+        , Convex.fromCylinder 5 0.8 1.6
+        , Convex.fromCone 6 0.9 1.4
+        ]
+
+
+directionFuzzer : Fuzzer Vec3.Vec3
+directionFuzzer =
+    Fuzz.map3
+        (\x y z ->
+            let
+                v =
+                    { x = x, y = y, z = z }
+            in
+            if Vec3.lengthSquared v < 1.0e-4 then
+                Vec3.zAxis
+
+            else
+                Vec3.normalize v
+        )
+        (Fuzz.floatRange -1 1)
+        (Fuzz.floatRange -1 1)
+        (Fuzz.floatRange -1 1)
+
+
+{-| Minimum overlap over the certified edge axes: fan containment of the
+normalized cross in both groups, measured from one endpoint of each support
+edge. First component covers the pairs the arc SAT tests, second also the
+near-parallel pairs it prunes.
+-}
+edgeMinOverlaps : Convex.Convex -> Convex.Convex -> Float -> ( Float, Float )
+edgeMinOverlaps convex1 convex2 start =
+    List.foldl
+        (\group1 acc1 ->
+            List.foldl
+                (\group2 ( s, l ) ->
+                    let
+                        d1 =
+                            Transform3d.rotate convex1.orientation group1.dir
+
+                        d2 =
+                            Transform3d.rotate convex2.orientation group2.dir
+
+                        c =
+                            Vec3.cross d1 d2
+                    in
+                    if Vec3.lengthSquared c < 1.0e-12 then
+                        ( s, l )
+
+                    else
+                        case pairMinOverlap convex1 convex2 d1 d2 (Vec3.normalize c) group1 group2 of
+                            Nothing ->
+                                ( s, l )
+
+                            Just o ->
+                                if Vec3.lengthSquared c < Const.parallelTolerance then
+                                    ( s, min l o )
+
+                                else
+                                    ( min s o, min l o )
+                )
+                acc1
+                convex2.uniqueEdges
+        )
+        ( start, start )
+        convex1.uniqueEdges
+
+
+{-| Support-consistent candidates for one direction pair; `Just` the
+smallest overlap, `Nothing` when no orientation is support-consistent.
+-}
+pairMinOverlap : Convex.Convex -> Convex.Convex -> Vec3.Vec3 -> Vec3.Vec3 -> Vec3.Vec3 -> Convex.EdgeGroup -> Convex.EdgeGroup -> Maybe Float
+pairMinOverlap convex1 convex2 d1 d2 u group1 group2 =
+    let
+        hit1 =
+            List.filterMap (fanHit convex1 d1 u) group1.edges
+
+        hit2 =
+            List.filterMap (fanHit convex2 d2 u) group2.edges
+    in
+    List.minimum
+        (List.concatMap
+            (\( s1, w1 ) ->
+                List.filterMap
+                    (\( s2, w2 ) ->
+                        if s1 > 0 && s2 < 0 then
+                            Just (Vec3.dot u (Vec3.sub w1 w2))
+
+                        else if s1 < 0 && s2 > 0 then
+                            Just (Vec3.dot u (Vec3.sub w2 w1))
+
+                        else
+                            Nothing
+                    )
+                    hit2
+            )
+            hit1
+        )
+
+
+{-| Fan containment of `±u` for one edge, in world frame: returns the sign
+of the contained orientation and one edge endpoint.
+-}
+fanHit : Convex.Convex -> Vec3.Vec3 -> Vec3.Vec3 -> Convex.Edge -> Maybe ( Float, Vec3.Vec3 )
+fanHit convex d u edge =
+    let
+        nA =
+            Transform3d.rotate convex.orientation edge.nA
+
+        nB =
+            Transform3d.rotate convex.orientation edge.nB
+
+        pA =
+            Vec3.dot u (Vec3.cross d nA)
+
+        pB =
+            Vec3.dot u (Vec3.cross nB d)
+    in
+    if pA > 0 && pB > 0 then
+        Just ( 1, VertexBuffer.get edge.i1 convex.vertexBuffer )
+
+    else if pA < 0 && pB < 0 then
+        Just ( -1, VertexBuffer.get edge.i1 convex.vertexBuffer )
+
+    else
+        Nothing

--- a/tests/Shapes/ConvexTest.elm
+++ b/tests/Shapes/ConvexTest.elm
@@ -14,6 +14,7 @@ import Extra.Expect as Expect
 import Fixtures.Convex
 import Internal.Transform3d as Transform3d
 import Internal.Vector3 as Vec3
+import Internal.VertexBuffer as VertexBuffer
 import Shapes.Convex as Convex
 import Test exposing (Test, describe, test)
 
@@ -282,10 +283,11 @@ uniqueEdges =
     describe ".uniqueEdges"
         [ test "works for a block" <|
             \_ ->
-                -- uniqueEdges now holds vertex-buffer indices in the canonical
+                -- uniqueEdges holds vertex-buffer indices in the canonical
                 -- placed traversal order (outer groups reversed, each group's
-                -- endpoints reversed) — read two-at-a-time per edge.
+                -- edges and endpoints reversed).
                 (Convex.fromBlock 2 2 2).uniqueEdges
+                    |> List.map (.edges >> List.concatMap (\{ i1, i2 } -> [ i1, i2 ]))
                     |> Expect.equal
                         [ [ 0, 4, 3, 7, 2, 6, 1, 5 ]
                         , [ 0, 3, 5, 6, 4, 7, 1, 2 ]
@@ -294,14 +296,49 @@ uniqueEdges =
         , test "block uniqueEdges has 12 edges across 3 directions" <|
             \_ ->
                 (Convex.fromBlock 2 3 5).uniqueEdges
-                    |> List.map (\group -> List.length group // 2)
+                    |> List.map (.edges >> List.length)
                     |> Expect.equal [ 4, 4, 4 ]
         , test "block from triangular mesh has 12 edges across 3 directions" <|
             \_ ->
                 (Fixtures.Convex.block Transform3d.atOrigin 2 3 5).uniqueEdges
-                    |> List.map (\group -> List.length group // 2)
+                    |> List.map (.edges >> List.length)
                     |> List.sort
                     |> Expect.equal [ 4, 4, 4 ]
+        , test "every edge arc is canonical and contains its outward bisector" <|
+            \_ ->
+                -- For an origin-centred convex: each group's normals must wind
+                -- positively around the representative's direction, and the
+                -- edge midpoint (pointing into the dihedral fan) must pass the
+                -- fan containment built from them.
+                [ Convex.fromBlock 2 3 5
+                , Convex.fromCylinder 12 1.5 2
+                , Convex.fromCone 7 1.5 2
+                ]
+                    |> List.concatMap
+                        (\convex ->
+                            List.concatMap
+                                (\{ dir, edges } ->
+                                    List.map
+                                        (\{ i1, i2, nA, nB } ->
+                                            let
+                                                mid =
+                                                    Vec3.sub
+                                                        (Vec3.add
+                                                            (VertexBuffer.get i1 convex.vertexBuffer)
+                                                            (VertexBuffer.get i2 convex.vertexBuffer)
+                                                        )
+                                                        (Vec3.scale 2 convex.position)
+                                            in
+                                            ( Vec3.dot (Vec3.cross nA nB) dir > 0
+                                            , Vec3.dot mid (Vec3.cross dir nA) > 0 && Vec3.dot mid (Vec3.cross nB dir) > 0
+                                            )
+                                        )
+                                        edges
+                                )
+                                convex.uniqueEdges
+                        )
+                    |> List.filter (\pair -> pair /= ( True, True ))
+                    |> Expect.equal []
         , test "works for a square pyramid" <|
             \_ ->
                 List.length Fixtures.Convex.squarePyramid.uniqueEdges


### PR DESCRIPTION
Implement gauss map for edge to edge collisions. It helps avoid projecting all convex vertices in this case. 
It also reduces allocations and the GC a bit.

https://cairnc.github.io/posts/improvements-to-the-separating-axis/