### PR TITLE
Joints become warm-started soft rows

### DIFF
--- a/src/Internal/ContactId.elm
+++ b/src/Internal/ContactId.elm
@@ -29,7 +29,9 @@ on `Contact`/`Equation`.
   - `featureKey` — which geometric feature touched, built by the constructors
     below. `featureString` / `toString` decode it for the sandbox and tests.
 
-User constraints, which are not warm-started, use the `0, 0` sentinel.
+User constraints warm-start under the reserved shape key `-1`; real shape
+keys are non-negative. Their `featureKey` packs constraint type, per-type
+ordinal and row (see `ConstraintsAcc` in `Equation`).
 
 Field budgets (under the 2^53 limit): body id < 2^18 → `bodyKey` < 2^36; shape
 index < 2^8 → `shapeKey` < 2^16; feature tag < 16 with four sub-ids each < 2^11.

--- a/src/Internal/Equation.elm
+++ b/src/Internal/Equation.elm
@@ -13,7 +13,7 @@ module Internal.Equation exposing
 
 import Internal.Body exposing (Body)
 import Internal.Constraint exposing (Constraint(..))
-import Internal.Contact exposing (Contact, PairGroup, SolverContact)
+import Internal.Contact exposing (PairGroup, SolverContact)
 import Internal.ContactCache as Cache exposing (ContactCache)
 import Internal.ContactId as ContactId
 import Internal.Shape exposing (CenterOfMassCoordinates)
@@ -39,7 +39,8 @@ type alias Jacobian =
 
 
 {-| Per-step solver context: dt and the soft-constraint coefficients for
-contact rows — a dynamic-dynamic set and a stiffer static-pair set.
+contact rows — a dynamic-dynamic set and a stiffer static-pair set — plus a
+stiffer-still set for joint rows.
 -}
 type alias Ctx =
     { dt : Float
@@ -50,6 +51,9 @@ type alias Ctx =
     , staticBiasRate : Float
     , staticMassScale : Float
     , staticImpulseScale : Float
+    , jointBiasRate : Float
+    , jointMassScale : Float
+    , jointImpulseScale : Float
     , warmStart : ContactCache WarmStart
     }
 
@@ -71,6 +75,9 @@ initCtx dt warmStart =
 
         static =
             makeSoft (2 * hertz) (0.5 * contactDampingRatio) dt
+
+        joint =
+            makeSoft (min jointHertz (1 / dt)) jointDampingRatio dt
     in
     { dt = dt
     , invDt = 1 / dt
@@ -80,6 +87,9 @@ initCtx dt warmStart =
     , staticBiasRate = static.biasRate
     , staticMassScale = static.massScale
     , staticImpulseScale = static.impulseScale
+    , jointBiasRate = joint.biasRate
+    , jointMassScale = joint.massScale
+    , jointImpulseScale = joint.impulseScale
     , warmStart = warmStart
     }
 
@@ -212,19 +222,27 @@ type alias EquationsGroup id =
 equationsForPair : Ctx -> PairGroup -> { contacts : List ContactEquations, constraints : List ConstraintEquation }
 equationsForPair ctx { body1, body2, contacts, constraints } =
     -- Multistep warm-start: fetch this body pair's cached warm-start list once
-    -- (the cache is keyed by body pair), then scan it per contact — instead of
+    -- (the cache is keyed by body pair), then scan it per equation — instead of
     -- walking the cache tree for every contact point.
     let
         warmStartList =
-            case contacts of
-                [] ->
-                    []
+            Cache.getGroup (ContactId.bodyKey body1.id body2.id) ctx.warmStart
 
-                _ ->
-                    Cache.getGroup (ContactId.bodyKey body1.id body2.id) ctx.warmStart
+        -- canonicalize cached joint lambdas to body-id order: a gravity-sort
+        -- swap flips the pivot rows' jacobians, so the seed flips with them
+        sign =
+            if body1.id - body2.id < 0 then
+                1
+
+            else
+                -1
     in
     { contacts = buildContactEquations ctx body1 body2 warmStartList contacts []
-    , constraints = List.foldl (addConstraintEquations ctx body1 body2) [] constraints
+    , constraints =
+        (List.foldl (addConstraintEquations ctx body1 body2 warmStartList sign)
+            { equations = [], pointToPoint = 0, hinge = 0, lock = 0, distance = 0 }
+            constraints
+        ).equations
     }
 
 
@@ -265,41 +283,68 @@ takeManifold shapeKey contacts acc =
                 { points = acc, rest = contacts }
 
 
-addConstraintEquations : Ctx -> Body -> Body -> Constraint CenterOfMassCoordinates -> List ConstraintEquation -> List ConstraintEquation
-addConstraintEquations ctx body1 body2 constraint =
+{-| Equations plus per-type constraint counters: a warm-start key is
+`typeTag·1024 + ordinal·8 + row`, so a seed follows its constraint by body
+pair, type and per-type ordinal — reconfiguring constraints of another type
+between the same bodies can't shift or cross-seed it.
+-}
+type alias ConstraintsAcc =
+    { equations : List ConstraintEquation
+    , pointToPoint : Int
+    , hinge : Int
+    , lock : Int
+    , distance : Int
+    }
+
+
+addConstraintEquations : Ctx -> Body -> Body -> List ( Int, Int, WarmStart ) -> Float -> Constraint CenterOfMassCoordinates -> ConstraintsAcc -> ConstraintsAcc
+addConstraintEquations ctx body1 body2 warmStartList sign constraint acc =
     case constraint of
         PointToPoint pivot1 pivot2 ->
-            addPointToPointConstraintEquations ctx body1 body2 pivot1 pivot2
+            { acc
+                | equations = addPointToPointConstraintEquations ctx body1 body2 warmStartList sign (acc.pointToPoint * 8) pivot1 pivot2 acc.equations
+                , pointToPoint = acc.pointToPoint + 1
+            }
 
         Hinge pivot1 axis1 pivot2 axis2 ->
-            addPointToPointConstraintEquations ctx body1 body2 pivot1 pivot2
-                >> addHingeRotationalConstraintEquations ctx body1 body2 axis1 axis2
+            { acc
+                | equations =
+                    acc.equations
+                        |> addPointToPointConstraintEquations ctx body1 body2 warmStartList sign (1024 + acc.hinge * 8) pivot1 pivot2
+                        |> addHingeRotationalConstraintEquations ctx body1 body2 (1024 + acc.hinge * 8 + 3) axis1 axis2
+                , hinge = acc.hinge + 1
+            }
 
         Lock pivot1 x1 y1 z1 pivot2 x2 y2 z2 ->
-            addPointToPointConstraintEquations ctx body1 body2 pivot1 pivot2
-                >> addLockRotationalConstraintEquations ctx body1 body2 x1 x2 y1 y2 z1 z2
+            { acc
+                | equations =
+                    acc.equations
+                        |> addPointToPointConstraintEquations ctx body1 body2 warmStartList sign (2048 + acc.lock * 8) pivot1 pivot2
+                        |> addLockRotationalConstraintEquations ctx body1 body2 (2048 + acc.lock * 8 + 3) x1 x2 y1 y2 z1 z2
+                , lock = acc.lock + 1
+            }
 
         Distance distance ->
-            addDistanceConstraintEquations ctx body1 body2 distance
+            { acc
+                | equations = addDistanceConstraintEquations ctx body1 body2 warmStartList sign (3072 + acc.distance * 8) distance acc.equations
+                , distance = acc.distance + 1
+            }
 
 
-addDistanceConstraintEquations : Ctx -> Body -> Body -> Float -> List ConstraintEquation -> List ConstraintEquation
-addDistanceConstraintEquations ctx body1 body2 distance =
+addDistanceConstraintEquations : Ctx -> Body -> Body -> List ( Int, Int, WarmStart ) -> Float -> Int -> Float -> List ConstraintEquation -> List ConstraintEquation
+addDistanceConstraintEquations ctx body1 body2 warmStartList sign key distance equations =
     let
-        spookA =
-            4.0 / (ctx.dt * (1 + 4 * defaultRelaxation))
-
-        spookB =
-            (4.0 * defaultRelaxation) / (1 + 4 * defaultRelaxation)
-
-        spookEps =
-            4.0 / (ctx.dt * ctx.dt * defaultStiffness * (1 + 4 * defaultRelaxation))
-
         halfDistance =
             distance / 2
 
+        origin1 =
+            Transform3d.originPoint body1.transform3d
+
+        origin2 =
+            Transform3d.originPoint body2.transform3d
+
         ni =
-            Vec3.direction (Transform3d.originPoint body2.transform3d) (Transform3d.originPoint body1.transform3d)
+            Vec3.direction origin2 origin1
 
         ri =
             Vec3.scale halfDistance ni
@@ -307,13 +352,11 @@ addDistanceConstraintEquations ctx body1 body2 distance =
         rj =
             Vec3.scale -halfDistance ni
 
-        contact =
-            { shapeKey = 0
-            , featureKey = 0
-            , pi = Vec3.add ri (Transform3d.originPoint body1.transform3d)
-            , pj = Vec3.add rj (Transform3d.originPoint body2.transform3d)
-            , ni = ni
-            }
+        -- signed violation along ni
+        c =
+            ((origin2.x + rj.x - origin1.x - ri.x) * ni.x)
+                + ((origin2.y + rj.y - origin1.y - ri.y) * ni.y)
+                + ((origin2.z + rj.z - origin1.z - ri.z) * ni.z)
 
         -- wA = Vec3.cross ni ri, vB = ni, wB = Vec3.cross rj ni
         jacobian =
@@ -327,20 +370,15 @@ addDistanceConstraintEquations ctx body1 body2 distance =
             , wBy = rj.z * ni.x - rj.x * ni.z
             , wBz = rj.x * ni.y - rj.y * ni.x
             }
+
+        seed =
+            sign * Cache.lookup -1 key 0 warmStartList
     in
-    (::)
-        { jacobian = jacobian
-        , solverB = computeSolverB body1 body2 jacobian (computeContactB spookA spookB 0 contact body1 body2 jacobian)
-        , solverInvC = computeSolverInvC spookEps body1 body2 jacobian
-        , spookEps = spookEps
-        , minImpulse = -defaultMaxImpulse
-        , maxImpulse = defaultMaxImpulse
-        , solverLambda = 0
-        }
+    softConstraintEquation ctx body1 body2 jacobian c key seed :: equations
 
 
-addHingeRotationalConstraintEquations : Ctx -> Body -> Body -> Vec3 -> Vec3 -> List ConstraintEquation -> List ConstraintEquation
-addHingeRotationalConstraintEquations ctx body1 body2 axis1 axis2 equations =
+addHingeRotationalConstraintEquations : Ctx -> Body -> Body -> Int -> Vec3 -> Vec3 -> List ConstraintEquation -> List ConstraintEquation
+addHingeRotationalConstraintEquations ctx body1 body2 key axis1 axis2 equations =
     let
         worldAxis2 =
             Transform3d.directionPlaceIn body2.transform3d axis2
@@ -349,12 +387,12 @@ addHingeRotationalConstraintEquations ctx body1 body2 axis1 axis2 equations =
             Vec3.tangents (Transform3d.directionPlaceIn body1.transform3d axis1)
     in
     equations
-        |> addRotationalEquation ctx body1 body2 ni1 worldAxis2
-        |> addRotationalEquation ctx body1 body2 ni2 worldAxis2
+        |> addRotationalEquation ctx body1 body2 key ni1 worldAxis2
+        |> addRotationalEquation ctx body1 body2 (key + 1) ni2 worldAxis2
 
 
-addLockRotationalConstraintEquations : Ctx -> Body -> Body -> Vec3 -> Vec3 -> Vec3 -> Vec3 -> Vec3 -> Vec3 -> List ConstraintEquation -> List ConstraintEquation
-addLockRotationalConstraintEquations ctx body1 body2 x1 x2 y1 y2 z1 z2 equations =
+addLockRotationalConstraintEquations : Ctx -> Body -> Body -> Int -> Vec3 -> Vec3 -> Vec3 -> Vec3 -> Vec3 -> Vec3 -> List ConstraintEquation -> List ConstraintEquation
+addLockRotationalConstraintEquations ctx body1 body2 key x1 x2 y1 y2 z1 z2 equations =
     let
         worldX1 =
             Transform3d.directionPlaceIn body1.transform3d x1
@@ -375,22 +413,17 @@ addLockRotationalConstraintEquations ctx body1 body2 x1 x2 y1 y2 z1 z2 equations
             Transform3d.directionPlaceIn body2.transform3d z2
     in
     equations
-        |> addRotationalEquation ctx body1 body2 worldX1 worldY2
-        |> addRotationalEquation ctx body1 body2 worldY1 worldZ2
-        |> addRotationalEquation ctx body1 body2 worldZ1 worldX2
+        |> addRotationalEquation ctx body1 body2 key worldX1 worldY2
+        |> addRotationalEquation ctx body1 body2 (key + 1) worldY1 worldZ2
+        |> addRotationalEquation ctx body1 body2 (key + 2) worldZ1 worldX2
 
 
-addRotationalEquation : Ctx -> Body -> Body -> Vec3 -> Vec3 -> List ConstraintEquation -> List ConstraintEquation
-addRotationalEquation ctx body1 body2 ni nj equations =
+addRotationalEquation : Ctx -> Body -> Body -> Int -> Vec3 -> Vec3 -> List ConstraintEquation -> List ConstraintEquation
+addRotationalEquation ctx body1 body2 key ni nj equations =
     let
-        spookA =
-            4.0 / (ctx.dt * (1 + 4 * defaultRelaxation))
-
-        spookB =
-            (4.0 * defaultRelaxation) / (1 + 4 * defaultRelaxation)
-
-        spookEps =
-            4.0 / (ctx.dt * ctx.dt * defaultStiffness * (1 + 4 * defaultRelaxation))
+        -- violation: the axes should stay perpendicular
+        c =
+            -(Vec3.dot ni nj)
 
         -- wA = Vec3.cross nj ni, vB = Vec3.zero, wB = Vec3.cross ni nj
         jacobian =
@@ -405,28 +438,17 @@ addRotationalEquation ctx body1 body2 ni nj equations =
             , wBz = ni.x * nj.y - ni.y * nj.x
             }
     in
-    { jacobian = jacobian
-    , solverB = computeSolverB body1 body2 jacobian (computeRotationalB spookA spookB { ni = ni, nj = nj, maxAngleCos = 0 } body1 body2 jacobian)
-    , solverInvC = computeSolverInvC spookEps body1 body2 jacobian
-    , spookEps = spookEps
-    , minImpulse = -defaultMaxImpulse
-    , maxImpulse = defaultMaxImpulse
-    , solverLambda = 0
-    }
-        :: equations
+    softConstraintEquation ctx body1 body2 jacobian c key 0 :: equations
 
 
-addPointToPointConstraintEquations : Ctx -> Body -> Body -> Vec3 -> Vec3 -> List ConstraintEquation -> List ConstraintEquation
-addPointToPointConstraintEquations ctx body1 body2 pivot1 pivot2 equations =
+addPointToPointConstraintEquations : Ctx -> Body -> Body -> List ( Int, Int, WarmStart ) -> Float -> Int -> Vec3 -> Vec3 -> List ConstraintEquation -> List ConstraintEquation
+addPointToPointConstraintEquations ctx body1 body2 warmStartList sign key pivot1 pivot2 equations =
     let
-        spookA =
-            4.0 / (ctx.dt * (1 + 4 * defaultRelaxation))
+        origin1 =
+            Transform3d.originPoint body1.transform3d
 
-        spookB =
-            (4.0 * defaultRelaxation) / (1 + 4 * defaultRelaxation)
-
-        spookEps =
-            4.0 / (ctx.dt * ctx.dt * defaultStiffness * (1 + 4 * defaultRelaxation))
+        origin2 =
+            Transform3d.originPoint body2.transform3d
 
         ri =
             Transform3d.directionPlaceIn body1.transform3d pivot1
@@ -435,15 +457,13 @@ addPointToPointConstraintEquations ctx body1 body2 pivot1 pivot2 equations =
             Transform3d.directionPlaceIn body2.transform3d pivot2
     in
     List.foldl
-        (\ni ->
+        (\( row, ni ) acc ->
             let
-                contact =
-                    { shapeKey = 0
-                    , featureKey = 0
-                    , pi = Vec3.add (Transform3d.originPoint body1.transform3d) ri
-                    , pj = Vec3.add (Transform3d.originPoint body2.transform3d) rj
-                    , ni = ni
-                    }
+                -- signed pivot separation along ni
+                c =
+                    ((origin2.x + rj.x - origin1.x - ri.x) * ni.x)
+                        + ((origin2.y + rj.y - origin1.y - ri.y) * ni.y)
+                        + ((origin2.z + rj.z - origin1.z - ri.z) * ni.z)
 
                 -- wA = Vec3.cross ni ri, vB = ni, wB = Vec3.cross rj ni
                 jacobian =
@@ -457,19 +477,14 @@ addPointToPointConstraintEquations ctx body1 body2 pivot1 pivot2 equations =
                     , wBy = rj.z * ni.x - rj.x * ni.z
                     , wBz = rj.x * ni.y - rj.y * ni.x
                     }
+
+                seed =
+                    sign * Cache.lookup -1 (key + row) 0 warmStartList
             in
-            (::)
-                { jacobian = jacobian
-                , solverB = computeSolverB body1 body2 jacobian (computeContactB spookA spookB 0 contact body1 body2 jacobian)
-                , solverInvC = computeSolverInvC spookEps body1 body2 jacobian
-                , spookEps = spookEps
-                , minImpulse = -defaultMaxImpulse
-                , maxImpulse = defaultMaxImpulse
-                , solverLambda = 0
-                }
+            softConstraintEquation ctx body1 body2 jacobian c (key + row) seed :: acc
         )
         equations
-        Vec3.basis
+        (List.indexedMap Tuple.pair Vec3.basis)
 
 
 manifoldEquations : Ctx -> Body -> Body -> List ( Int, Int, WarmStart ) -> SolverContact -> List SolverContact -> ContactEquations
@@ -782,109 +797,62 @@ restitutionThreshold =
     1
 
 
-{-| The Spook soft-constraint parameters, derived from a stiffness and a
-relaxation (the number of timesteps over which a constraint violation is
-relaxed), exactly as cannon.js does:
-
-    spookA   = 4 / (dt · (1 + 4·relaxation))                 -- position feedback
-    spookB   = 4·relaxation / (1 + 4·relaxation)             -- velocity coefficient
-    spookEps = 4 / (dt² · stiffness · (1 + 4·relaxation))    -- regularization
-
-`spookB` < 1 leaves a little of the relative velocity uncanceled each step
-(velocity-level damping), and `spookEps` gives the constraint a small
-compliance that dissipates the position-feedback energy — together they keep
-resting stacks calm instead of buzzing.
-
-Each builder computes the three values as plain locals (no wrapper record) from
-`dt` and the relaxation/stiffness it has on hand, passes `spookA`/`spookB` into
-`computeB`, and stores `spookEps` on the equation for the solver's
-per-iteration regularizer. Contacts source relaxation/stiffness here from the
-module defaults, but this is the seam to combine them per contact from the two
-shapes' materials (the way `friction`/`bounciness` already are) — which is why
-the values are not cached globally on `Ctx`.
-
+{-| Joint stiffness in hertz for the soft constraint rows. A statically loaded
+row's resting violation scales as `impulseScale/(massScale·biasRate)` — the
+bias must re-earn what the bleed drains — so joints run much stiffer than
+contacts: 60 Hz leaves a loaded hinge sagging under 1 mm/1 m at 60 fps, and
+the whipped 5-box chain is calm at the `1/dt` clamp down to 30 fps.
 -}
-defaultRelaxation : Float
-defaultRelaxation =
-    3
+jointHertz : Float
+jointHertz =
+    60
 
 
-defaultStiffness : Float
-defaultStiffness =
-    10000000
+{-| Joint damping ratio (zeta): stiff correction with little overshoot.
+-}
+jointDampingRatio : Float
+jointDampingRatio =
+    2
 
 
-{-| A joint equation: a static jacobian + solver scalars plus its accumulated
-`solverLambda` (re-allocated each iteration to update the lambda).
+{-| A joint equation: a soft row like the contact normals but without the
+λ ≥ 0 clamp: `Δλ = -mass·(gW + bias) - impulseScale·λ`, with
+`mass = massScale/K` and `bias = biasRate·C` folded in at build time.
+`featureKey` identifies the row in the warm-start cache (see `ConstraintsAcc`).
 -}
 type alias ConstraintEquation =
     { jacobian : Jacobian
-    , solverB : Float
-    , solverInvC : Float
-    , spookEps : Float
+    , mass : Float
+    , bias : Float
+    , impulseScale : Float
     , minImpulse : Float
     , maxImpulse : Float
+    , featureKey : Int
     , solverLambda : Float
     }
 
 
-{-| Translate a joint's Spook `velocityB` to the total-velocity scheme:
-solver bodies now carry full velocities (gravity and forces applied at init),
-so the target folds the build-time row velocity back in — the old
-`-dt·GiMf` gravity anticipation cancels against the gravity tick in the
-initialized totals.
--}
-computeSolverB : Body -> Body -> Jacobian -> Float -> Float
-computeSolverB bi bj jacobian velocityB =
-    velocityB + computeGW bi bj jacobian
-
-
-{-| Constant 1 / (G·M⁻¹·Gᵀ + ε) scaling each iteration's correction.
--}
-computeSolverInvC : Float -> Body -> Body -> Jacobian -> Float
-computeSolverInvC spookEps bi bj jacobian =
-    1 / (computeGimgt bi bj jacobian + spookEps)
-
-
-{-| B with the position term in the velocity stream (Baumgarte), for the
-joints' contact-like rows.
--}
-computeContactB : Float -> Float -> Float -> Contact -> Body -> Body -> Jacobian -> Float
-computeContactB spookA spookB bounciness { pi, pj, ni } bi bj jacobian =
+softConstraintEquation : Ctx -> Body -> Body -> Jacobian -> Float -> Int -> Float -> ConstraintEquation
+softConstraintEquation ctx body1 body2 jacobian c featureKey seed =
     let
-        g =
-            ((pj.x - pi.x) * ni.x)
-                + ((pj.y - pi.y) * ni.y)
-                + ((pj.z - pi.z) * ni.z)
+        k =
+            computeGimgt body1 body2 jacobian
     in
-    -g * spookA - computeContactGW bounciness ni bi bj jacobian * spookB
+    { jacobian = jacobian
+    , mass =
+        -- particles have no inertia for purely angular rows
+        if k > 0 then
+            ctx.jointMassScale / k
 
-
-computeContactGW : Float -> Vec3 -> Body -> Body -> Jacobian -> Float
-computeContactGW bounciness ni bi bj jacobian =
-    (bounciness + 1)
-        * (Vec3.dot bj.velocity ni - Vec3.dot bi.velocity ni)
-        + (bj.angularVelocity.x * jacobian.wBx + bj.angularVelocity.y * jacobian.wBy + bj.angularVelocity.z * jacobian.wBz)
-        + (bi.angularVelocity.x * jacobian.wAx + bi.angularVelocity.y * jacobian.wAy + bi.angularVelocity.z * jacobian.wAz)
-
-
-type alias RotationalEquation =
-    { ni : Vec3
-    , nj : Vec3
-    , maxAngleCos : Float
+        else
+            0
+    , bias = ctx.jointBiasRate * c
+    , impulseScale = ctx.jointImpulseScale
+    , minImpulse = -defaultMaxImpulse
+    , maxImpulse = defaultMaxImpulse
+    , featureKey = featureKey
+    , solverLambda = seed
     }
-
-
-computeRotationalB : Float -> Float -> RotationalEquation -> Body -> Body -> Jacobian -> Float
-computeRotationalB spookA spookB { ni, nj, maxAngleCos } bi bj jacobian =
-    let
-        g =
-            maxAngleCos - Vec3.dot ni nj
-
-        gW =
-            computeGW bi bj jacobian
-    in
-    -g * spookA - gW * spookB
 
 
 {-| Compute G x inv(M) x G', the effective inverse mass for this constraint.

--- a/src/Internal/Solver.elm
+++ b/src/Internal/Solver.elm
@@ -305,9 +305,8 @@ solve dt gravity iterations pairGroups maxId bodiesWithIds warmStart =
             }
 
 
-{-| Build next frame's warm-start cache: one insert per contact-bearing pair,
-keyed by body-pair key. Constraints are never warm-started, so only contacts
-are collected.
+{-| Build next frame's warm-start cache: one insert per pair with contacts or
+constraints, keyed by body-pair key.
 -}
 collectGroupCaches : List (EquationsGroup id) -> ContactCache Equation.WarmStart -> ContactCache Equation.WarmStart
 collectGroupCaches groups acc =
@@ -316,24 +315,25 @@ collectGroupCaches groups acc =
             acc
 
         group :: rest ->
-            case group.contacts of
-                [] ->
-                    collectGroupCaches rest acc
+            let
+                bodyKey =
+                    ContactId.bodyKey group.body1.body.id group.body2.body.id
 
-                _ :: _ ->
-                    let
-                        bodyKey =
-                            ContactId.bodyKey group.body1.body.id group.body2.body.id
+                tangentSign =
+                    if group.body1.body.id - group.body2.body.id < 0 then
+                        1
 
-                        tangentSign =
-                            if group.body1.body.id - group.body2.body.id < 0 then
-                                1
-
-                            else
-                                -1
-                    in
-                    collectGroupCaches rest
-                        (Cache.insertGroup bodyKey (warmStartEntries tangentSign group.contacts []) acc)
+                    else
+                        -1
+            in
+            collectGroupCaches rest
+                (Cache.insertGroup bodyKey
+                    (warmStartEntries tangentSign
+                        group.contacts
+                        (constraintWarmStartEntries tangentSign group.constraints [])
+                    )
+                    acc
+                )
 
 
 {-| A pair's warm-start entries: each point's solved normal lambda keyed by
@@ -390,6 +390,22 @@ pointWarmStartEntries points acc =
         { data, normalLambda } :: rest ->
             pointWarmStartEntries rest
                 (( data.shapeKey, data.featureKey, normalLambda ) :: acc)
+
+
+{-| Joint lambdas keyed by `(-1, featureKey)` — the reserved shape key never
+collides with real shape pairs. Sign-canonicalized to body-id order, like the
+tangent impulse.
+-}
+constraintWarmStartEntries : Float -> List ConstraintEquation -> List ( Int, Int, Equation.WarmStart ) -> List ( Int, Int, Equation.WarmStart )
+constraintWarmStartEntries tangentSign constraints acc =
+    case constraints of
+        [] ->
+            acc
+
+        { featureKey, solverLambda } :: rest ->
+            constraintWarmStartEntries tangentSign
+                rest
+                (( -1, featureKey, tangentSign * solverLambda ) :: acc)
 
 
 {-| Solve a multi-body island: two sweeps per iteration — non-friction (normals
@@ -749,7 +765,7 @@ solveVelocityConstraints body1 body2 acc deltalambdaTot equations =
                         + (jacobian.wBx * body2.wX + jacobian.wBy * body2.wY + jacobian.wBz * body2.wZ)
 
                 deltalambdaPrev =
-                    constraint.solverInvC * (constraint.solverB - gWlambda - constraint.spookEps * solverLambda)
+                    -constraint.mass * (gWlambda + constraint.bias) - constraint.impulseScale * solverLambda
 
                 deltalambda =
                     if solverLambda + deltalambdaPrev - constraint.minImpulse < 0 then
@@ -765,11 +781,12 @@ solveVelocityConstraints body1 body2 acc deltalambdaTot equations =
                 (applyVelocityBody1 deltalambda jacobian body1)
                 (applyVelocityBody2 deltalambda jacobian body2)
                 ({ jacobian = jacobian
-                 , solverB = constraint.solverB
-                 , solverInvC = constraint.solverInvC
-                 , spookEps = constraint.spookEps
+                 , mass = constraint.mass
+                 , bias = constraint.bias
+                 , impulseScale = constraint.impulseScale
                  , minImpulse = constraint.minImpulse
                  , maxImpulse = constraint.maxImpulse
+                 , featureKey = constraint.featureKey
                  , solverLambda = solverLambda + deltalambda
                  }
                     :: acc

--- a/tests/ConstraintTest.elm
+++ b/tests/ConstraintTest.elm
@@ -1,0 +1,254 @@
+module ConstraintTest exposing (suite)
+
+{-| End-to-end accuracy tests for the constraint (joint) solver: pivots must
+not drift apart, hinge axes must stay aligned under sustained gravity load,
+and statically loaded joints must settle to rest.
+-}
+
+import Angle
+import Axis3d
+import Block3d
+import Direction3d
+import Expect
+import Frame3d
+import Length
+import Physics exposing (Body, onEarth)
+import Physics.Constraint as Constraint exposing (Constraint)
+import Physics.Material as Material
+import Physics.Shape as Shape
+import Point3d exposing (Point3d)
+import Speed
+import Test exposing (Test, describe, test)
+import Vector3d
+
+
+{-| A small static block to anchor joints to.
+-}
+anchor : Body
+anchor =
+    Physics.static
+        [ ( Shape.block (Block3d.centeredOn Frame3d.atOrigin ( Length.meters 0.2, Length.meters 0.2, Length.meters 0.2 )), Material.wood )
+        ]
+
+
+unitBox : Body
+unitBox =
+    Physics.block
+        (Block3d.centeredOn Frame3d.atOrigin
+            ( Length.meters 1, Length.meters 1, Length.meters 1 )
+        )
+        Material.wood
+
+
+{-| Thread contacts through `steps` simulation calls, waking all bodies each
+step so sleeping can't freeze the scene mid-measurement.
+-}
+run : Int -> (Int -> Maybe (Int -> List Constraint)) -> List ( Int, Body ) -> List ( Int, Body )
+run steps constrain bodies =
+    loop steps constrain Physics.emptyContacts bodies
+
+
+loop : Int -> (Int -> Maybe (Int -> List Constraint)) -> Physics.Contacts Int -> List ( Int, Body ) -> List ( Int, Body )
+loop steps constrain contacts bodies =
+    if steps <= 0 then
+        bodies
+
+    else
+        let
+            ( nextBodies, nextContacts ) =
+                Physics.simulate { onEarth | contacts = contacts, constrain = constrain }
+                    (List.map (Tuple.mapSecond Physics.wake) bodies)
+        in
+        loop (steps - 1) constrain nextContacts nextBodies
+
+
+lookup : Int -> List ( Int, Body ) -> Maybe Body
+lookup wanted bodies =
+    bodies
+        |> List.filter (\( id, _ ) -> id == wanted)
+        |> List.head
+        |> Maybe.map Tuple.second
+
+
+{-| World-space distance between the two bodies' pivot points, in meters.
+-}
+pivotGap : Point3d Length.Meters Physics.BodyCoordinates -> Point3d Length.Meters Physics.BodyCoordinates -> Body -> Body -> Float
+pivotGap pivot1 pivot2 body1 body2 =
+    Length.inMeters
+        (Point3d.distanceFrom
+            (Point3d.placeIn (Physics.frame body1) pivot1)
+            (Point3d.placeIn (Physics.frame body2) pivot2)
+        )
+
+
+speed : Body -> Float
+speed body =
+    Speed.inMetersPerSecond (Vector3d.length (Physics.velocity body))
+
+
+constrainPair : List Constraint -> Int -> Maybe (Int -> List Constraint)
+constrainPair constraints id1 =
+    if id1 == 0 then
+        Just
+            (\id2 ->
+                if id2 == 1 then
+                    constraints
+
+                else
+                    []
+            )
+
+    else
+        Nothing
+
+
+suite : Test
+suite =
+    describe "constraints"
+        [ test "pointToPoint: swinging pendulum keeps the pivots together" <|
+            \_ ->
+                let
+                    -- box hanging 1 m below the anchor by its top-center point,
+                    -- swung 30° to the side around the pivot so it keeps moving
+                    pivotOnBox =
+                        Point3d.meters 0 0 1
+
+                    scene =
+                        [ ( 0, anchor )
+                        , ( 1
+                          , unitBox
+                                |> Physics.moveTo (Point3d.meters 0 0 -1)
+                                |> Physics.rotateAround Axis3d.y (Angle.degrees 30)
+                          )
+                        ]
+
+                    result =
+                        run 300
+                            (constrainPair [ Constraint.pointToPoint Point3d.origin pivotOnBox ])
+                            scene
+                in
+                case ( lookup 0 result, lookup 1 result ) of
+                    ( Just anchorBody, Just box ) ->
+                        pivotGap Point3d.origin pivotOnBox anchorBody box
+                            |> Expect.atMost 0.002
+
+                    _ ->
+                        Expect.fail "bodies are missing"
+        , test "hinge: sideways-loaded door keeps its axis aligned and settles" <|
+            \_ ->
+                let
+                    -- door hangs off the side of a vertical hinge, so gravity
+                    -- loads the rotational rows with a constant torque
+                    doorAxis =
+                        Axis3d.through (Point3d.meters 1 0 0) Direction3d.z
+
+                    scene =
+                        [ ( 0, anchor )
+                        , ( 1
+                          , Physics.block
+                                (Block3d.centeredOn Frame3d.atOrigin
+                                    ( Length.meters 1, Length.meters 0.2, Length.meters 0.2 )
+                                )
+                                Material.wood
+                                |> Physics.moveTo (Point3d.meters -1 0 0)
+                          )
+                        ]
+
+                    result =
+                        run 300
+                            (constrainPair [ Constraint.hinge Axis3d.z doorAxis ])
+                            scene
+                in
+                case ( lookup 0 result, lookup 1 result ) of
+                    ( Just anchorBody, Just door ) ->
+                        let
+                            axisError =
+                                1 - Direction3d.zComponent (Direction3d.placeIn (Physics.frame door) Direction3d.z)
+                        in
+                        Expect.all
+                            [ \_ -> axisError |> Expect.atMost 0.00001
+                            , \_ -> pivotGap Point3d.origin (Point3d.meters 1 0 0) anchorBody door |> Expect.atMost 0.002
+                            , \_ -> speed door |> Expect.atMost 0.000001
+                            ]
+                            ()
+
+                    _ ->
+                        Expect.fail "bodies are missing"
+        , test "pointToPoint: swinging 5-box chain stays taut" <|
+            \_ ->
+                let
+                    -- boxes chained face-to-face off the anchor, started
+                    -- horizontally so the chain whips down before settling
+                    chainLink id1 =
+                        Just
+                            (\id2 ->
+                                if id2 - id1 == 1 then
+                                    [ Constraint.pointToPoint
+                                        (Point3d.meters 0.5 0 0)
+                                        (Point3d.meters -0.5 0 0)
+                                    ]
+
+                                else
+                                    []
+                            )
+
+                    scene =
+                        ( 0, anchor )
+                            :: List.map
+                                (\i -> ( i, unitBox |> Physics.moveTo (Point3d.meters (toFloat i) 0 0) ))
+                                (List.range 1 5)
+
+                    result =
+                        run 600 chainLink scene
+
+                    gaps =
+                        List.map2
+                            (\( _, upper ) ( _, lower ) ->
+                                pivotGap (Point3d.meters 0.5 0 0) (Point3d.meters -0.5 0 0) upper lower
+                            )
+                            result
+                            (List.drop 1 result)
+
+                    speeds =
+                        List.map (\( _, body ) -> speed body) result
+                in
+                Expect.all
+                    [ \_ -> List.maximum gaps |> Maybe.withDefault (1 / 0) |> Expect.atMost 0.005
+                    , -- an energy bound: the chain may still swing, but must not blow up
+                      \_ -> List.maximum speeds |> Maybe.withDefault (1 / 0) |> Expect.atMost 10
+                    ]
+                    ()
+        , test "lock: cantilevered box stays rigidly attached and settles" <|
+            \_ ->
+                let
+                    -- box locked 1 m off the side of the anchor: gravity loads
+                    -- both the translational and the rotational rows
+                    frameOnBox =
+                        Frame3d.atPoint (Point3d.meters 1 0 0)
+
+                    scene =
+                        [ ( 0, anchor )
+                        , ( 1, unitBox |> Physics.moveTo (Point3d.meters -1 0 0) )
+                        ]
+
+                    result =
+                        run 300
+                            (constrainPair [ Constraint.lock Frame3d.atOrigin frameOnBox ])
+                            scene
+                in
+                case ( lookup 0 result, lookup 1 result ) of
+                    ( Just anchorBody, Just box ) ->
+                        let
+                            axisError =
+                                1 - Direction3d.zComponent (Direction3d.placeIn (Physics.frame box) Direction3d.z)
+                        in
+                        Expect.all
+                            [ \_ -> axisError |> Expect.atMost 0.00001
+                            , \_ -> pivotGap Point3d.origin (Point3d.meters 1 0 0) anchorBody box |> Expect.atMost 0.001
+                            , \_ -> speed box |> Expect.atMost 0.000001
+                            ]
+                            ()
+
+                    _ ->
+                        Expect.fail "bodies are missing"
+        ]


### PR DESCRIPTION
Constraints now use the same makeSoft rows as the contacts, at 60 Hz zeta=2 clamped to 1/dt. 